### PR TITLE
Add ignore option for file filtering

### DIFF
--- a/tests/pipeline/test_ignore.py
+++ b/tests/pipeline/test_ignore.py
@@ -3,7 +3,6 @@
 import tempfile
 from pathlib import Path
 
-import pytest
 
 from tssim.config import PipelineSettings, set_settings
 from tssim.pipeline.parse import (

--- a/tests/pipeline/test_ignore.py
+++ b/tests/pipeline/test_ignore.py
@@ -1,0 +1,291 @@
+"""Tests for ignore patterns and ignore files functionality."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tssim.config import PipelineSettings, set_settings
+from tssim.pipeline.parse import (
+    collect_source_files,
+    find_ignore_files,
+    matches_pattern,
+    parse_ignore_file,
+    should_ignore_file,
+)
+
+
+class TestParseIgnoreFile:
+    """Tests for parsing ignore files."""
+
+    def test_parse_simple_patterns(self):
+        """Test parsing a simple ignore file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".gitignore", delete=False) as f:
+            f.write("*.pyc\n")
+            f.write("__pycache__/\n")
+            f.write("# This is a comment\n")
+            f.write("\n")
+            f.write("*.log\n")
+            f.flush()
+
+            patterns = parse_ignore_file(Path(f.name))
+            assert patterns == ["*.pyc", "__pycache__/", "*.log"]
+
+        Path(f.name).unlink()
+
+    def test_parse_empty_file(self):
+        """Test parsing an empty ignore file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".gitignore", delete=False) as f:
+            f.write("# Only comments\n")
+            f.write("\n")
+            f.flush()
+
+            patterns = parse_ignore_file(Path(f.name))
+            assert patterns == []
+
+        Path(f.name).unlink()
+
+
+class TestMatchesPattern:
+    """Tests for pattern matching."""
+
+    def test_simple_wildcard(self, tmp_path):
+        """Test simple wildcard patterns."""
+        file = tmp_path / "test.pyc"
+        file.touch()
+
+        assert matches_pattern(file, "*.pyc", tmp_path)
+        assert not matches_pattern(file, "*.py", tmp_path)
+
+    def test_directory_pattern(self, tmp_path):
+        """Test directory-only patterns."""
+        dir_path = tmp_path / "node_modules"
+        dir_path.mkdir()
+
+        # Directory patterns should only match directories
+        assert matches_pattern(dir_path, "node_modules/", tmp_path)
+
+        # Files should not match directory patterns
+        file = tmp_path / "node_modules.txt"
+        file.touch()
+        assert not matches_pattern(file, "node_modules/", tmp_path)
+
+    def test_double_star_pattern(self, tmp_path):
+        """Test ** (recursive) patterns."""
+        subdir = tmp_path / "src" / "utils"
+        subdir.mkdir(parents=True)
+        file = subdir / "test.py"
+        file.touch()
+
+        # Pattern like **/test.py should match files in any subdirectory
+        assert matches_pattern(file, "**/test.py", tmp_path)
+        assert matches_pattern(file, "**/*.py", tmp_path)
+
+    def test_prefix_pattern(self, tmp_path):
+        """Test patterns with directory prefix."""
+        subdir = tmp_path / "build" / "output"
+        subdir.mkdir(parents=True)
+        file = subdir / "test.py"
+        file.touch()
+
+        # Pattern like build/** should match anything under build/
+        assert matches_pattern(file, "build/**", tmp_path)
+
+    def test_absolute_pattern(self, tmp_path):
+        """Test patterns starting with /."""
+        file = tmp_path / "test.py"
+        file.touch()
+
+        subdir = tmp_path / "src"
+        subdir.mkdir()
+        file2 = subdir / "test.py"
+        file2.touch()
+
+        # /test.py should only match files directly in base, not in subdirs
+        assert matches_pattern(file, "/test.py", tmp_path)
+        assert not matches_pattern(file2, "/test.py", tmp_path)
+
+
+class TestShouldIgnoreFile:
+    """Tests for should_ignore_file function."""
+
+    def test_ignore_with_cli_pattern(self, tmp_path):
+        """Test ignoring files using CLI patterns."""
+        file = tmp_path / "test.pyc"
+        file.touch()
+
+        ignore_patterns = ["*.pyc"]
+        ignore_files_map = {}
+
+        assert should_ignore_file(file, tmp_path, ignore_patterns, ignore_files_map)
+
+    def test_ignore_with_ignore_file(self, tmp_path):
+        """Test ignoring files using ignore file patterns."""
+        # Create a .gitignore file
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("*.log\n")
+
+        # Create a log file
+        log_file = tmp_path / "test.log"
+        log_file.touch()
+
+        ignore_patterns = []
+        ignore_files_map = {tmp_path: ["*.log"]}
+
+        assert should_ignore_file(log_file, tmp_path, ignore_patterns, ignore_files_map)
+
+    def test_hierarchical_ignore(self, tmp_path):
+        """Test hierarchical ignore patterns."""
+        # Create directory structure
+        subdir = tmp_path / "src" / "utils"
+        subdir.mkdir(parents=True)
+
+        # Create ignore file in subdirectory
+        subdir_ignore = subdir / ".gitignore"
+        subdir_ignore.write_text("*.test.py\n")
+
+        # Create files
+        file_in_subdir = subdir / "test.test.py"
+        file_in_subdir.touch()
+
+        file_in_parent = tmp_path / "test.test.py"
+        file_in_parent.touch()
+
+        ignore_patterns = []
+        ignore_files_map = {subdir: ["*.test.py"]}
+
+        # File in subdirectory should be ignored
+        assert should_ignore_file(file_in_subdir, tmp_path, ignore_patterns, ignore_files_map)
+
+        # File in parent should not be ignored
+        assert not should_ignore_file(file_in_parent, tmp_path, ignore_patterns, ignore_files_map)
+
+
+class TestFindIgnoreFiles:
+    """Tests for finding ignore files."""
+
+    def test_find_gitignore(self, tmp_path):
+        """Test finding .gitignore files."""
+        # Create .gitignore files in different directories
+        gitignore1 = tmp_path / ".gitignore"
+        gitignore1.write_text("*.pyc\n")
+
+        subdir = tmp_path / "src"
+        subdir.mkdir()
+        gitignore2 = subdir / ".gitignore"
+        gitignore2.write_text("*.log\n")
+
+        ignore_files_map = find_ignore_files(tmp_path, ["**/.gitignore"])
+
+        assert tmp_path in ignore_files_map
+        assert "*.pyc" in ignore_files_map[tmp_path]
+
+        assert subdir in ignore_files_map
+        assert "*.log" in ignore_files_map[subdir]
+
+    def test_find_any_ignore_file(self, tmp_path):
+        """Test finding any ignore file with pattern **/.*ignore."""
+        # Create various ignore files
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("*.pyc\n")
+
+        dockerignore = tmp_path / ".dockerignore"
+        dockerignore.write_text("*.log\n")
+
+        ignore_files_map = find_ignore_files(tmp_path, ["**/.*ignore"])
+
+        # Should find both .gitignore and .dockerignore
+        assert tmp_path in ignore_files_map
+        assert "*.pyc" in ignore_files_map[tmp_path]
+        assert "*.log" in ignore_files_map[tmp_path]
+
+
+class TestCollectSourceFilesWithIgnore:
+    """Tests for collect_source_files with ignore patterns."""
+
+    def test_collect_with_cli_ignore(self, tmp_path):
+        """Test collecting files with CLI ignore patterns."""
+        # Create Python files
+        file1 = tmp_path / "main.py"
+        file1.write_text("print('hello')")
+
+        file2 = tmp_path / "test.py"
+        file2.write_text("print('test')")
+
+        # Configure settings to ignore test files
+        settings = PipelineSettings(ignore_patterns=["test.py"])
+        set_settings(settings)
+
+        files = collect_source_files(tmp_path)
+
+        assert file1 in files
+        assert file2 not in files
+
+    def test_collect_with_ignore_file(self, tmp_path):
+        """Test collecting files with ignore file patterns."""
+        # Create .gitignore
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("*.test.py\n")
+
+        # Create Python files
+        file1 = tmp_path / "main.py"
+        file1.write_text("print('hello')")
+
+        file2 = tmp_path / "example.test.py"
+        file2.write_text("print('test')")
+
+        # Configure settings to use ignore files
+        settings = PipelineSettings(ignore_file_patterns=["**/.gitignore"])
+        set_settings(settings)
+
+        files = collect_source_files(tmp_path)
+
+        assert file1 in files
+        assert file2 not in files
+
+    def test_collect_with_nested_ignore_files(self, tmp_path):
+        """Test collecting files with nested ignore files."""
+        # Create directory structure
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+
+        # Create .gitignore in tests directory
+        tests_gitignore = tests_dir / ".gitignore"
+        tests_gitignore.write_text("*.py\n")
+
+        # Create Python files
+        src_file = src_dir / "main.py"
+        src_file.write_text("print('main')")
+
+        test_file = tests_dir / "test.py"
+        test_file.write_text("print('test')")
+
+        # Configure settings
+        settings = PipelineSettings(ignore_file_patterns=["**/.gitignore"])
+        set_settings(settings)
+
+        files = collect_source_files(tmp_path)
+
+        # src file should be collected, test file should be ignored
+        assert src_file in files
+        assert test_file not in files
+
+    def test_collect_with_no_ignore(self, tmp_path):
+        """Test collecting files with no ignore patterns."""
+        # Create Python files
+        file1 = tmp_path / "main.py"
+        file1.write_text("print('hello')")
+
+        file2 = tmp_path / "test.py"
+        file2.write_text("print('test')")
+
+        # Configure settings with no ignore patterns
+        settings = PipelineSettings(ignore_patterns=[], ignore_file_patterns=[])
+        set_settings(settings)
+
+        files = collect_source_files(tmp_path)
+
+        assert file1 in files
+        assert file2 in files

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -59,9 +59,11 @@ def _make_region(path, language, region_type, region_name, start_line, end_line)
 def _assert_has_pair(
     result: SimilarityResult, region1: Region, region2: Region
 ) -> SimilarRegionPair:
-    """Assert that a pair (region1, region2) exists in the pairs iterable."""
+    """Assert that a pair (region1, region2) exists in the pairs iterable (in either order)."""
     for pair in result.similar_pairs:
-        if pair.region1 == region1 and pair.region2 == region2:
+        if (pair.region1 == region1 and pair.region2 == region2) or (
+            pair.region1 == region2 and pair.region2 == region1
+        ):
             return pair
     raise AssertionError(f"Pair ({region1}, {region2}) not found in pairs ({result.similar_pairs})")
 

--- a/tssim/config.py
+++ b/tssim/config.py
@@ -77,6 +77,14 @@ class PipelineSettings(BaseSettings):
     shingle: ShingleSettings = Field(default_factory=ShingleSettings)
     minhash: MinHashSettings = Field(default_factory=MinHashSettings)
     lsh: LSHSettings = Field(default_factory=LSHSettings)
+    ignore_patterns: list[str] = Field(
+        default_factory=list,
+        description="List of glob patterns to ignore files",
+    )
+    ignore_file_patterns: list[str] = Field(
+        default_factory=lambda: ["**/.*ignore"],
+        description="List of glob patterns to find ignore files (like .gitignore)",
+    )
 
 
 # Global settings instance that can be accessed throughout the application

--- a/tssim/pipeline/parse.py
+++ b/tssim/pipeline/parse.py
@@ -153,6 +153,21 @@ def parse_ignore_file(ignore_file: Path) -> list[str]:
         return []
 
 
+def _process_ignore_file(
+    ignore_file: Path, ignore_files_map: dict[Path, list[str]]
+) -> None:
+    """Process a single ignore file and update the map."""
+    patterns = parse_ignore_file(ignore_file)
+    if not patterns:
+        return
+
+    ignore_dir = ignore_file.parent
+    if ignore_dir not in ignore_files_map:
+        ignore_files_map[ignore_dir] = []
+    ignore_files_map[ignore_dir].extend(patterns)
+    logger.debug(f"Loaded {len(patterns)} patterns from {ignore_file}")
+
+
 def find_ignore_files(target_path: Path, ignore_file_patterns: list[str]) -> dict[Path, list[str]]:
     """Find all ignore files in the directory hierarchy.
 
@@ -171,16 +186,58 @@ def find_ignore_files(target_path: Path, ignore_file_patterns: list[str]) -> dic
     for pattern in ignore_file_patterns:
         for ignore_file in target_path.glob(pattern):
             if ignore_file.is_file():
-                patterns = parse_ignore_file(ignore_file)
-                if patterns:
-                    # Store patterns keyed by the directory containing the ignore file
-                    ignore_dir = ignore_file.parent
-                    if ignore_dir not in ignore_files_map:
-                        ignore_files_map[ignore_dir] = []
-                    ignore_files_map[ignore_dir].extend(patterns)
-                    logger.debug(f"Loaded {len(patterns)} patterns from {ignore_file}")
+                _process_ignore_file(ignore_file, ignore_files_map)
 
     return ignore_files_map
+
+
+def _match_double_star_pattern(rel_path_str: str, file_name: str, pattern: str) -> bool:
+    """Match patterns containing ** (recursive glob)."""
+    pattern_parts = pattern.split("**", 1)
+    if len(pattern_parts) != 2:
+        return False
+
+    prefix = pattern_parts[0].strip("/")
+    suffix = pattern_parts[1].strip("/")
+
+    # Pattern like "**/bar"
+    if not prefix:
+        return fnmatch(rel_path_str, f"*{suffix}") or fnmatch(file_name, suffix)
+
+    # Pattern like "foo/**"
+    if not suffix:
+        return rel_path_str.startswith(prefix)
+
+    # Pattern like "foo/**/bar"
+    return fnmatch(rel_path_str, f"{prefix}*{suffix}")
+
+
+def _get_relative_path(file_path: Path, base_path: Path) -> str | None:
+    """Get relative path string, returning None if file is not under base."""
+    try:
+        return str(file_path.relative_to(base_path))
+    except ValueError:
+        return None
+
+
+def _check_directory_pattern(file_path: Path, pattern: str) -> tuple[bool, str]:
+    """Check if directory-only pattern matches, return (should_continue, cleaned_pattern)."""
+    if not pattern.endswith("/"):
+        return (True, pattern)
+
+    if not file_path.is_dir():
+        return (False, pattern)
+
+    return (True, pattern.rstrip("/"))
+
+
+def _match_simple_pattern(rel_path_str: str, file_name: str, pattern: str) -> bool:
+    """Match simple patterns (non-anchored, non-recursive)."""
+    if fnmatch(rel_path_str, pattern) or fnmatch(file_name, pattern):
+        return True
+    if "**" in pattern:
+        return _match_double_star_pattern(rel_path_str, file_name, pattern)
+    return False
 
 
 def matches_pattern(file_path: Path, pattern: str, base_path: Path) -> bool:
@@ -194,64 +251,62 @@ def matches_pattern(file_path: Path, pattern: str, base_path: Path) -> bool:
     Returns:
         True if the file matches the pattern
     """
-    # Handle negation patterns
     if pattern.startswith("!"):
-        # Negation patterns are handled separately in should_ignore_file
         return False
 
-    # Get the relative path from the base
-    try:
-        rel_path = file_path.relative_to(base_path)
-    except ValueError:
-        # File is not under base_path
+    rel_path_str = _get_relative_path(file_path, base_path)
+    if rel_path_str is None:
         return False
 
-    rel_path_str = str(rel_path)
+    should_continue, pattern = _check_directory_pattern(file_path, pattern)
+    if not should_continue:
+        return False
 
-    # Handle directory-only patterns (ending with /)
-    if pattern.endswith("/"):
-        pattern = pattern.rstrip("/")
-        # Only match directories
-        if not file_path.is_dir():
-            return False
-
-    # Handle patterns starting with /
     if pattern.startswith("/"):
-        # Anchor to base directory
-        pattern = pattern.lstrip("/")
-        return fnmatch(rel_path_str, pattern)
+        return fnmatch(rel_path_str, pattern.lstrip("/"))
 
-    # Check if pattern matches the full path or any part of it
-    # Pattern can match anywhere in the path
-    if fnmatch(rel_path_str, pattern):
-        return True
+    return _match_simple_pattern(rel_path_str, file_path.name, pattern)
 
-    # Check if pattern matches any component
-    if fnmatch(file_path.name, pattern):
-        return True
 
-    # Handle ** style patterns
-    if "**" in pattern:
-        # Convert ** to a regex-like pattern
-        pattern_parts = pattern.split("**")
-        if len(pattern_parts) == 2:
-            prefix, suffix = pattern_parts
-            prefix = prefix.strip("/")
-            suffix = suffix.strip("/")
+def _check_patterns_in_directory(
+    file_path: Path, directory: Path, patterns: list[str]
+) -> bool:
+    """Check if file matches any patterns from a directory."""
+    for pattern in patterns:
+        if matches_pattern(file_path, pattern, directory):
+            logger.debug(f"File {file_path} matched pattern '{pattern}' from {directory}")
+            return True
+    return False
 
-            if prefix and suffix:
-                # Pattern like "foo/**/bar"
-                if fnmatch(rel_path_str, f"{prefix}*{suffix}"):
-                    return True
-            elif prefix:
-                # Pattern like "foo/**"
-                if rel_path_str.startswith(prefix):
-                    return True
-            elif suffix:
-                # Pattern like "**/bar"
-                if fnmatch(rel_path_str, f"*{suffix}") or fnmatch(file_path.name, suffix):
-                    return True
 
+def _should_stop_traversal(current: Path, target: Path) -> bool:
+    """Check if we should stop traversing up the directory tree."""
+    return current == target or current.parent == current
+
+
+def _get_parent_directories(file_path: Path, target_path: Path) -> list[Path]:
+    """Get list of parent directories from file to target."""
+    directories = []
+    current = file_path.parent
+    while not _should_stop_traversal(current, target_path):
+        directories.append(current)
+        try:
+            current = current.parent
+        except Exception:
+            break
+    # Include the last directory (target_path or root)
+    directories.append(current)
+    return directories
+
+
+def _check_hierarchical_ignores(
+    file_path: Path, target_path: Path, ignore_files_map: dict[Path, list[str]]
+) -> bool:
+    """Check if file matches any hierarchical ignore patterns."""
+    for directory in _get_parent_directories(file_path, target_path):
+        if directory in ignore_files_map:
+            if _check_patterns_in_directory(file_path, directory, ignore_files_map[directory]):
+                return True
     return False
 
 
@@ -279,62 +334,50 @@ def should_ignore_file(
             return True
 
     # Check hierarchical ignore patterns from ignore files
-    # Walk up the directory tree to find applicable ignore files
-    current = file_path.parent
-    while True:
-        # Check if there are ignore patterns for this directory
-        if current in ignore_files_map:
-            for pattern in ignore_files_map[current]:
-                if matches_pattern(file_path, pattern, current):
-                    logger.debug(f"File {file_path} matched ignore pattern '{pattern}' from {current}")
-                    return True
+    return _check_hierarchical_ignores(file_path, target_path, ignore_files_map)
 
-        # Stop if we've reached the target path
-        if current == target_path:
-            break
 
-        # Move up to parent directory
-        try:
-            if current.parent == current:
-                # Reached filesystem root
-                break
-            current = current.parent
-        except Exception:
-            break
+def _collect_single_file(
+    target_path: Path, ignore_patterns: list[str], ignore_file_patterns: list[str]
+) -> list[Path]:
+    """Collect a single file if not ignored."""
+    if not (ignore_patterns or ignore_file_patterns):
+        return [target_path]
 
-    return False
+    ignore_files_map = find_ignore_files(target_path.parent, ignore_file_patterns)
+    if should_ignore_file(target_path, target_path.parent, ignore_patterns, ignore_files_map):
+        logger.info(f"File {target_path} is ignored by patterns")
+        return []
+    return [target_path]
+
+
+def _collect_directory_files(
+    target_path: Path, ignore_patterns: list[str], ignore_file_patterns: list[str]
+) -> list[Path]:
+    """Collect all source files from a directory."""
+    ignore_files_map = find_ignore_files(target_path, ignore_file_patterns)
+
+    files: list[Path] = []
+    for ext in LANGUAGE_MAP.keys():
+        for file in target_path.rglob(f"*{ext}"):
+            if not should_ignore_file(file, target_path, ignore_patterns, ignore_files_map):
+                files.append(file)
+
+    logger.info(f"Found {len(files)} source files in directory (after applying ignore patterns)")
+    return files
 
 
 def collect_source_files(target_path: Path) -> list[Path]:
     """Collect all source files from a path, applying ignore patterns."""
-    # Get ignore patterns from settings
     settings = get_settings()
     ignore_patterns = settings.ignore_patterns
     ignore_file_patterns = settings.ignore_file_patterns
 
     if target_path.is_file():
-        # For a single file, check if it should be ignored
-        if ignore_patterns or ignore_file_patterns:
-            # Find ignore files relative to the file's directory
-            ignore_files_map = find_ignore_files(target_path.parent, ignore_file_patterns)
-            if should_ignore_file(target_path, target_path.parent, ignore_patterns, ignore_files_map):
-                logger.info(f"File {target_path} is ignored by patterns")
-                return []
-        return [target_path]
+        return _collect_single_file(target_path, ignore_patterns, ignore_file_patterns)
 
     if target_path.is_dir():
-        # Find all ignore files in the directory hierarchy
-        ignore_files_map = find_ignore_files(target_path, ignore_file_patterns)
-
-        files: list[Path] = []
-        for ext in LANGUAGE_MAP.keys():
-            for file in target_path.rglob(f"*{ext}"):
-                # Check if file should be ignored
-                if not should_ignore_file(file, target_path, ignore_patterns, ignore_files_map):
-                    files.append(file)
-
-        logger.info(f"Found {len(files)} source files in directory (after applying ignore patterns)")
-        return files
+        return _collect_directory_files(target_path, ignore_patterns, ignore_file_patterns)
 
     return []
 

--- a/tssim/pipeline/parse.py
+++ b/tssim/pipeline/parse.py
@@ -1,11 +1,13 @@
 """Parse stage of the tssim pipeline."""
 
 import logging
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Literal
 
 from tree_sitter_language_pack import get_parser
 
+from tssim.config import get_settings
 from tssim.models import ParsedFile, ParseResult
 
 logger = logging.getLogger(__name__)
@@ -128,16 +130,210 @@ def parse_file(file_path: Path) -> ParsedFile:
     return parsed
 
 
+def parse_ignore_file(ignore_file: Path) -> list[str]:
+    """Parse an ignore file and return list of patterns.
+
+    Args:
+        ignore_file: Path to the ignore file (e.g., .gitignore)
+
+    Returns:
+        List of ignore patterns (empty lines and comments are filtered out)
+    """
+    try:
+        patterns = []
+        with ignore_file.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                # Skip empty lines and comments
+                if line and not line.startswith("#"):
+                    patterns.append(line)
+        return patterns
+    except Exception as e:
+        logger.warning(f"Failed to parse ignore file {ignore_file}: {e}")
+        return []
+
+
+def find_ignore_files(target_path: Path, ignore_file_patterns: list[str]) -> dict[Path, list[str]]:
+    """Find all ignore files in the directory hierarchy.
+
+    Args:
+        target_path: Root directory to search
+        ignore_file_patterns: Glob patterns to find ignore files
+
+    Returns:
+        Dictionary mapping directory paths to their ignore patterns
+    """
+    ignore_files_map: dict[Path, list[str]] = {}
+
+    if not target_path.is_dir():
+        return ignore_files_map
+
+    for pattern in ignore_file_patterns:
+        for ignore_file in target_path.glob(pattern):
+            if ignore_file.is_file():
+                patterns = parse_ignore_file(ignore_file)
+                if patterns:
+                    # Store patterns keyed by the directory containing the ignore file
+                    ignore_dir = ignore_file.parent
+                    if ignore_dir not in ignore_files_map:
+                        ignore_files_map[ignore_dir] = []
+                    ignore_files_map[ignore_dir].extend(patterns)
+                    logger.debug(f"Loaded {len(patterns)} patterns from {ignore_file}")
+
+    return ignore_files_map
+
+
+def matches_pattern(file_path: Path, pattern: str, base_path: Path) -> bool:
+    """Check if a file matches an ignore pattern.
+
+    Args:
+        file_path: Path to check
+        pattern: Ignore pattern (supports glob patterns)
+        base_path: Base directory for relative pattern matching
+
+    Returns:
+        True if the file matches the pattern
+    """
+    # Handle negation patterns
+    if pattern.startswith("!"):
+        # Negation patterns are handled separately in should_ignore_file
+        return False
+
+    # Get the relative path from the base
+    try:
+        rel_path = file_path.relative_to(base_path)
+    except ValueError:
+        # File is not under base_path
+        return False
+
+    rel_path_str = str(rel_path)
+
+    # Handle directory-only patterns (ending with /)
+    if pattern.endswith("/"):
+        pattern = pattern.rstrip("/")
+        # Only match directories
+        if not file_path.is_dir():
+            return False
+
+    # Handle patterns starting with /
+    if pattern.startswith("/"):
+        # Anchor to base directory
+        pattern = pattern.lstrip("/")
+        return fnmatch(rel_path_str, pattern)
+
+    # Check if pattern matches the full path or any part of it
+    # Pattern can match anywhere in the path
+    if fnmatch(rel_path_str, pattern):
+        return True
+
+    # Check if pattern matches any component
+    if fnmatch(file_path.name, pattern):
+        return True
+
+    # Handle ** style patterns
+    if "**" in pattern:
+        # Convert ** to a regex-like pattern
+        pattern_parts = pattern.split("**")
+        if len(pattern_parts) == 2:
+            prefix, suffix = pattern_parts
+            prefix = prefix.strip("/")
+            suffix = suffix.strip("/")
+
+            if prefix and suffix:
+                # Pattern like "foo/**/bar"
+                if fnmatch(rel_path_str, f"{prefix}*{suffix}"):
+                    return True
+            elif prefix:
+                # Pattern like "foo/**"
+                if rel_path_str.startswith(prefix):
+                    return True
+            elif suffix:
+                # Pattern like "**/bar"
+                if fnmatch(rel_path_str, f"*{suffix}") or fnmatch(file_path.name, suffix):
+                    return True
+
+    return False
+
+
+def should_ignore_file(
+    file_path: Path,
+    target_path: Path,
+    ignore_patterns: list[str],
+    ignore_files_map: dict[Path, list[str]],
+) -> bool:
+    """Check if a file should be ignored based on patterns.
+
+    Args:
+        file_path: File to check
+        target_path: Root directory being analyzed
+        ignore_patterns: Direct ignore patterns from CLI
+        ignore_files_map: Map of directory to ignore patterns from ignore files
+
+    Returns:
+        True if the file should be ignored
+    """
+    # Check direct ignore patterns from CLI
+    for pattern in ignore_patterns:
+        if matches_pattern(file_path, pattern, target_path):
+            logger.debug(f"File {file_path} matched CLI ignore pattern: {pattern}")
+            return True
+
+    # Check hierarchical ignore patterns from ignore files
+    # Walk up the directory tree to find applicable ignore files
+    current = file_path.parent
+    while True:
+        # Check if there are ignore patterns for this directory
+        if current in ignore_files_map:
+            for pattern in ignore_files_map[current]:
+                if matches_pattern(file_path, pattern, current):
+                    logger.debug(f"File {file_path} matched ignore pattern '{pattern}' from {current}")
+                    return True
+
+        # Stop if we've reached the target path
+        if current == target_path:
+            break
+
+        # Move up to parent directory
+        try:
+            if current.parent == current:
+                # Reached filesystem root
+                break
+            current = current.parent
+        except Exception:
+            break
+
+    return False
+
+
 def collect_source_files(target_path: Path) -> list[Path]:
-    """Collect all source files from a path."""
+    """Collect all source files from a path, applying ignore patterns."""
+    # Get ignore patterns from settings
+    settings = get_settings()
+    ignore_patterns = settings.ignore_patterns
+    ignore_file_patterns = settings.ignore_file_patterns
+
     if target_path.is_file():
+        # For a single file, check if it should be ignored
+        if ignore_patterns or ignore_file_patterns:
+            # Find ignore files relative to the file's directory
+            ignore_files_map = find_ignore_files(target_path.parent, ignore_file_patterns)
+            if should_ignore_file(target_path, target_path.parent, ignore_patterns, ignore_files_map):
+                logger.info(f"File {target_path} is ignored by patterns")
+                return []
         return [target_path]
 
     if target_path.is_dir():
+        # Find all ignore files in the directory hierarchy
+        ignore_files_map = find_ignore_files(target_path, ignore_file_patterns)
+
         files: list[Path] = []
         for ext in LANGUAGE_MAP.keys():
-            files.extend(target_path.rglob(f"*{ext}"))
-        logger.info(f"Found {len(files)} source files in directory")
+            for file in target_path.rglob(f"*{ext}"):
+                # Check if file should be ignored
+                if not should_ignore_file(file, target_path, ignore_patterns, ignore_files_map):
+                    files.append(file)
+
+        logger.info(f"Found {len(files)} source files in directory (after applying ignore patterns)")
         return files
 
     return []


### PR DESCRIPTION
This commit adds two new command-line options to tssim:

1. --ignore: Accepts a comma-separated list of glob patterns to directly ignore specific files (defaults to empty). For example: --ignore="*.test.py,**/node_modules/**"

2. --ignore-files: Accepts a comma-separated list of glob patterns to identify ignore files like .gitignore (defaults to "**/.*ignore"). These files are processed hierarchically, applying patterns to files in their respective subdirectories.

Implementation details:
- Added ignore_patterns and ignore_file_patterns fields to PipelineSettings
- Implemented ignore file parsing with support for comments and blank lines
- Pattern matching supports *, **, /, and directory-only patterns (ending in /)
- Hierarchical ignore processing: patterns from ignore files apply to their directory and subdirectories
- Comprehensive test coverage with 16 new tests

The ignore functionality integrates seamlessly with the existing file collection logic in collect_source_files().