### PR TITLE
Create ruleset system for game rules

### DIFF
--- a/testing-framework/run_tests.py
+++ b/testing-framework/run_tests.py
@@ -91,9 +91,11 @@ class DuplicationTester:
         start_time = time.time()
         try:
             # Run tssim using uv run with JSON output
+            # Use --ruleset none to match jscpd behavior (no normalization)
             result = subprocess.run(
                 ['uv', 'run', 'tssim', str(repo_path), '--log-level', 'ERROR',
-                 '--format', 'json', '--output', str(json_output_file)],
+                 '--format', 'json', '--output', str(json_output_file),
+                 '--ruleset', 'none'],
                 capture_output=True,
                 text=True,
                 timeout=300,

--- a/tssim/config.py
+++ b/tssim/config.py
@@ -13,6 +13,11 @@ class RulesSettings(BaseSettings):
         env_prefix="RULES_",
     )
 
+    ruleset: str = Field(
+        default="default",
+        description="Ruleset profile to use (none, default)",
+    )
+
     rules: Optional[str] = Field(
         default=None,
         description="Comma-separated list of rule specifications",

--- a/tssim/pipeline/rules/engine.py
+++ b/tssim/pipeline/rules/engine.py
@@ -128,14 +128,35 @@ def build_default_rules() -> list[Rule]:
 
     This replaces the default normalizers (e.g., PythonImportNormalizer).
 
+    Default rules normalize code for similarity detection by:
+    - Skipping language-specific imports
+    - Skipping comments and docstrings
+    - Normalizing literal values to <LIT> tokens
+    - Anonymizing identifiers to VAR_N tokens
+
     Returns:
         List of default Rule objects
     """
     from .parser import parse_rule
 
-    # Convert PythonImportNormalizer to a rule
     default_rules = [
+        # Python-specific rules
         parse_rule("python:skip:nodes=import_statement|import_from_statement"),
+        parse_rule("python:skip:nodes=comment"),
+        parse_rule("python:skip:nodes=string_content"),  # Docstrings and string literals
+        parse_rule("python:replace_value:nodes=string|integer|float,value=<LIT>"),
+        parse_rule("python:anonymize_identifiers:nodes=identifier,scheme=flat,prefix=VAR"),
+
+        # JavaScript/TypeScript rules
+        parse_rule("javascript:skip:nodes=import_statement|export_statement"),
+        parse_rule("javascript:skip:nodes=comment"),
+        parse_rule("javascript:replace_value:nodes=string|number|template_string,value=<LIT>"),
+        parse_rule("javascript:anonymize_identifiers:nodes=identifier,scheme=flat,prefix=VAR"),
+
+        parse_rule("typescript:skip:nodes=import_statement|export_statement"),
+        parse_rule("typescript:skip:nodes=comment"),
+        parse_rule("typescript:replace_value:nodes=string|number|template_string,value=<LIT>"),
+        parse_rule("typescript:anonymize_identifiers:nodes=identifier,scheme=flat,prefix=VAR"),
     ]
 
     return default_rules


### PR DESCRIPTION
This commit adds a new --ruleset CLI option to allow users to select predefined rule profiles for code normalization during similarity detection.

Features:
- New --ruleset CLI argument with two options: 'none' and 'default'
- Default value is 'default' for backward compatibility with enhanced rules
- 'none' profile: No normalization rules applied (raw code comparison)
- 'default' profile: Comprehensive normalization for Python, JS, and TS:
  - Skip imports/exports
  - Skip comments and docstrings
  - Normalize literals (strings, numbers) to <LIT> tokens
  - Anonymize identifiers to VAR_N tokens

Implementation details:
- Added ruleset field to RulesSettings in config.py
- Expanded build_default_rules() with Python, TypeScript, and JavaScript rules
- Updated build_rule_engine() to handle ruleset selection with precedence:
  1. ruleset (none or default)
  2. --rules parameter (overrides ruleset)
  3. --rules-file parameter (overrides both)
- Updated benchmark to use 'none' ruleset for jscpd comparison
- Updated tests to parameterize by ruleset with appropriate expectations

All tests pass and CI checks (lint, type, test, radon) pass successfully.