### PR TITLE
Update CLI options and add ruleset listing

### DIFF
--- a/tests/pipeline/rules/test_engine.py
+++ b/tests/pipeline/rules/test_engine.py
@@ -202,12 +202,13 @@ class TestBuildDefaultRules:
 
     def test_default_rules_exist(self):
         """Test that default rules are created."""
-        rules = build_default_rules()
-        assert len(rules) > 0
+        rules_with_descriptions = build_default_rules()
+        assert len(rules_with_descriptions) > 0
 
     def test_default_python_import_skip(self, parser):
         """Test that default rules skip Python imports."""
-        rules = build_default_rules()
+        rules_with_descriptions = build_default_rules()
+        rules = [rule for rule, _ in rules_with_descriptions]
         engine = RuleEngine(rules)
 
         root, source = parse_source("import os\n", parser)

--- a/tssim/cli.py
+++ b/tssim/cli.py
@@ -18,7 +18,7 @@ from tssim.config import (
     ShingleSettings,
     set_settings,
 )
-from tssim.formatters import format_as_json, format_as_sarif
+from tssim.formatters import format_as_sarif
 from tssim.models.similarity import Region, RegionSignature, SimilarRegionGroup, SimilarityResult
 from tssim.pipeline.pipeline import run_pipeline
 
@@ -222,7 +222,7 @@ def _run_pipeline_with_ui(path: Path, output_format: str) -> SimilarityResult:
 
     Args:
         path: Path to analyze
-        output_format: Output format (console, json, sarif)
+        output_format: Output format (console, sarif)
 
     Returns:
         The similarity result
@@ -249,15 +249,12 @@ def _handle_output(
 
     Args:
         result: The similarity result
-        output_format: Output format (console, json, sarif)
+        output_format: Output format (console, sarif)
         output_path: Path to output file, or None for stdout
         log_level: Logging level for debug output
         show_diff: If True, show diff between first two regions in each group
     """
-    if output_format.lower() == "json":
-        output_text = format_as_json(result, pretty=True)
-        _write_output(output_text, output_path)
-    elif output_format.lower() == "sarif":
+    if output_format.lower() == "sarif":
         output_text = format_as_sarif(result, pretty=True)
         _write_output(output_text, output_path)
     else:  # console
@@ -276,6 +273,30 @@ def _parse_patterns(pattern_string: str) -> list[str]:
         List of stripped non-empty patterns
     """
     return [p.strip() for p in pattern_string.split(",") if p.strip()]
+
+
+def _print_rulesets(listing_type: str) -> None:
+    """Print available rulesets based on listing type.
+
+    Args:
+        listing_type: Type of listing ('non' for non-default, 'default' for default)
+    """
+    rulesets = {
+        "none": "No normalization rules applied - raw AST comparison",
+        "default": "Standard normalization (skip imports/comments, anonymize identifiers, replace literals)",
+        "loose": "Aggressive normalization (includes default + operator/type/collection canonicalization)",
+    }
+
+    console.print("\n[bold blue]Available Rulesets:[/bold blue]\n")
+
+    if listing_type == "default":
+        console.print("[green]default[/green] (default)")
+        console.print(f"  {rulesets['default']}\n")
+    else:  # listing_type == "non"
+        console.print("[yellow]none[/yellow]")
+        console.print(f"  {rulesets['none']}\n")
+        console.print("[cyan]loose[/cyan]")
+        console.print(f"  {rulesets['loose']}\n")
 
 
 def _create_rules_settings(rules: str, rules_file: str, ruleset: str) -> RulesSettings:
@@ -300,8 +321,6 @@ def _configure_settings(
     rules: str,
     rules_file: str,
     ruleset: str,
-    shingle_k: int,
-    minhash_num_perm: int,
     threshold: float,
     min_lines: int,
     ignore: str,
@@ -313,8 +332,6 @@ def _configure_settings(
         rules: Comma-separated list of rule specifications
         rules_file: Path to file containing rule specifications (one per line)
         ruleset: Ruleset profile to use (none, default, loose)
-        shingle_k: Length of k-grams for shingling
-        minhash_num_perm: Number of MinHash permutations
         threshold: LSH similarity threshold
         min_lines: Minimum number of lines for a match
         ignore: Comma-separated list of glob patterns to ignore files
@@ -322,8 +339,8 @@ def _configure_settings(
     """
     settings = PipelineSettings(
         rules=_create_rules_settings(rules, rules_file, ruleset),
-        shingle=ShingleSettings(k=shingle_k),
-        minhash=MinHashSettings(num_perm=minhash_num_perm),
+        shingle=ShingleSettings(),  # Uses default k=3
+        minhash=MinHashSettings(),  # Uses default num_perm=128
         lsh=LSHSettings(threshold=threshold, min_lines=min_lines),
         ignore_patterns=_parse_patterns(ignore),
         ignore_file_patterns=_parse_patterns(ignore_files),
@@ -336,7 +353,7 @@ def _check_result_errors(result: SimilarityResult, output_format: str) -> None:
 
     Args:
         result: The similarity result
-        output_format: Output format (console, json, sarif)
+        output_format: Output format (console, sarif)
     """
     if result.success_count == 0 and result.failure_count > 0:
         if output_format.lower() == "console":
@@ -372,22 +389,10 @@ def _check_result_errors(result: SimilarityResult, output_format: str) -> None:
     help="Ruleset profile to use (default: default)",
 )
 @click.option(
-    "--shingle-k",
-    type=int,
-    default=3,
-    help="Length of k-grams for shingling (default: 3)",
-)
-@click.option(
-    "--shingle-include-text",
-    is_flag=True,
-    default=False,
-    help="Include node text in shingles for more specificity",
-)
-@click.option(
-    "--minhash-num-perm",
-    type=int,
-    default=128,
-    help="Number of MinHash permutations (default: 128, higher = more accurate)",
+    "--list-ruleset",
+    type=click.Choice(["non", "default"], case_sensitive=False),
+    default=None,
+    help="List available rulesets (non: list non-default rulesets, default: list default ruleset)",
 )
 @click.option(
     "--threshold",
@@ -404,7 +409,7 @@ def _check_result_errors(result: SimilarityResult, output_format: str) -> None:
 @click.option(
     "--format",
     "output_format",
-    type=click.Choice(["console", "json", "sarif"], case_sensitive=False),
+    type=click.Choice(["console", "sarif"], case_sensitive=False),
     default="console",
     help="Output format (default: console)",
 )
@@ -439,9 +444,7 @@ def main(
     rules: str,
     rules_file: str,
     ruleset: str,
-    shingle_k: int,
-    shingle_include_text: bool,
-    minhash_num_perm: int,
+    list_ruleset: str | None,
     threshold: float,
     min_lines: int,
     output_format: str,
@@ -457,6 +460,11 @@ def main(
     """
     setup_logging(log_level.upper())
 
+    # Handle --list-ruleset option
+    if list_ruleset is not None:
+        _print_rulesets(list_ruleset)
+        sys.exit(0)
+
     if path is None:
         console.print("[bold red]Error:[/bold red] PATH is required")
         console.print("Try 'tssim --help' for more information.")
@@ -466,8 +474,6 @@ def main(
         rules,
         rules_file,
         ruleset,
-        shingle_k,
-        minhash_num_perm,
         threshold,
         min_lines,
         ignore,

--- a/tssim/pipeline/rules/engine.py
+++ b/tssim/pipeline/rules/engine.py
@@ -124,34 +124,34 @@ class RuleEngine:
         self._identifier_counters.clear()
 
 
-def build_default_rules() -> list[Rule]:
+def build_default_rules() -> list[tuple[Rule, str]]:
     return [
         # Python-specific rules
-        parse_rule("python:skip:nodes=import_statement|import_from_statement"),
-        parse_rule("python:skip:nodes=comment"),
-        parse_rule("python:skip:nodes=string_content"),  # Docstrings and string literals
-        parse_rule("python:replace_value:nodes=string|integer|float|number|template_string|true|false|none|null|undefined,value=<LIT>"),
-        parse_rule("python:anonymize_identifiers:nodes=identifier,scheme=flat,prefix=VAR"),
+        (parse_rule("python:skip:nodes=import_statement|import_from_statement"), "Skip Python import statements"),
+        (parse_rule("python:skip:nodes=comment"), "Skip Python comments"),
+        (parse_rule("python:skip:nodes=string_content"), "Skip Python docstrings and string literals"),
+        (parse_rule("python:replace_value:nodes=string|integer|float|number|template_string|true|false|none|null|undefined,value=<LIT>"), "Replace Python literal values with placeholder"),
+        (parse_rule("python:anonymize_identifiers:nodes=identifier,scheme=flat,prefix=VAR"), "Anonymize Python identifiers to generic variables"),
 
         # JavaScript/TypeScript rules
-        parse_rule("javascript|typescript:skip:nodes=import_statement|export_statement"),
-        parse_rule("javascript|typescript:skip:nodes=comment"),
-        parse_rule("javascript|typescript:replace_value:nodes=string|number|template_string,value=<LIT>"),
-        parse_rule("javascript|typescript:anonymize_identifiers:nodes=identifier,scheme=flat,prefix=VAR"),
+        (parse_rule("javascript|typescript:skip:nodes=import_statement|export_statement"), "Skip JS/TS import and export statements"),
+        (parse_rule("javascript|typescript:skip:nodes=comment"), "Skip JS/TS comments"),
+        (parse_rule("javascript|typescript:replace_value:nodes=string|number|template_string,value=<LIT>"), "Replace JS/TS literal values with placeholder"),
+        (parse_rule("javascript|typescript:anonymize_identifiers:nodes=identifier,scheme=flat,prefix=VAR"), "Anonymize JS/TS identifiers to generic variables"),
     ]
 
 
-def build_loose_rules() -> list[Rule]:
+def build_loose_rules() -> list[tuple[Rule, str]]:
     return [
         *build_default_rules(),
 
         # Python
-        parse_rule("python:replace_name:nodes=binary_operator|boolean_operator|comparison_operator|unary_operator,token=<OP>"),
-        parse_rule("python:canonicalize_types:nodes=type"),
-        parse_rule("python:replace_name:nodes=list|dictionary|tuple|set,token=<COLL>"),
+        (parse_rule("python:replace_name:nodes=binary_operator|boolean_operator|comparison_operator|unary_operator,token=<OP>"), "Replace Python operators with generic placeholder"),
+        (parse_rule("python:canonicalize_types:nodes=type"), "Canonicalize Python type annotations"),
+        (parse_rule("python:replace_name:nodes=list|dictionary|tuple|set,token=<COLL>"), "Replace Python collections with generic placeholder"),
 
         # JS/TS:
-        parse_rule("typescript:canonicalize_types:nodes=type_annotation|predefined_type|type_identifier"),
-        parse_rule("javascript|typescript:replace_name:nodes=array|object,token=<COLL>"),
-        parse_rule("javascript|typescript:replace_name:nodes=binary_expression|unary_expression|update_expression|assignment_expression|ternary_expression,token=<EXP>")
+        (parse_rule("typescript:canonicalize_types:nodes=type_annotation|predefined_type|type_identifier"), "Canonicalize TypeScript type annotations"),
+        (parse_rule("javascript|typescript:replace_name:nodes=array|object,token=<COLL>"), "Replace JS/TS collections with generic placeholder"),
+        (parse_rule("javascript|typescript:replace_name:nodes=binary_expression|unary_expression|update_expression|assignment_expression|ternary_expression,token=<EXP>"), "Replace JS/TS expressions with generic placeholder")
     ]

--- a/tssim/pipeline/rules_factory.py
+++ b/tssim/pipeline/rules_factory.py
@@ -64,6 +64,24 @@ def _log_active_rules(rules: list[Rule]) -> None:
         )
 
 
+def get_ruleset_with_descriptions(ruleset: str) -> list[tuple[Rule, str]]:
+    """Get a ruleset with rule descriptions for display purposes.
+
+    Args:
+        ruleset: Name of the ruleset (default, loose, none)
+
+    Returns:
+        List of tuples containing (Rule, description)
+    """
+    ruleset = ruleset.lower()
+    if ruleset == "default":
+        return build_default_rules()
+    elif ruleset == "loose":
+        return build_loose_rules()
+    else:  # none
+        return []
+
+
 def build_rule_engine(settings: PipelineSettings) -> RuleEngine:
     # Start with ruleset-based defaults
     ruleset = settings.rules.ruleset.lower()
@@ -71,10 +89,12 @@ def build_rule_engine(settings: PipelineSettings) -> RuleEngine:
 
     if ruleset == "default":
         logger.info("Using 'default' ruleset")
-        rules = build_default_rules()
+        # Extract just the rules from the tuples
+        rules = [rule for rule, _ in build_default_rules()]
     elif ruleset == "loose":
         logger.info("Using 'loose' ruleset")
-        rules = build_loose_rules()
+        # Extract just the rules from the tuples
+        rules = [rule for rule, _ in build_loose_rules()]
 
     if settings.rules.rules:
         rules = _load_rules_from_string(settings.rules.rules)


### PR DESCRIPTION
… --list-ruleset

Remove:
- --shingle-k, --shingle-include-text, --minhash-num-perm CLI options (now use default values: k=3, num_perm=128)
- json output format from --format option (keep console, sarif)

Add:
- --list-ruleset option with 'non' and 'default' parameters
  - 'default': lists the default ruleset
  - 'non': lists non-default rulesets (none, loose)

This simplifies the CLI by removing advanced tuning options and focuses on the ruleset-based workflow. The removed parameters now use sensible defaults from config.py.