### PR TITLE
Find inline diff display library

### DIFF
--- a/tssim/cli.py
+++ b/tssim/cli.py
@@ -19,7 +19,7 @@ from tssim.config import (
     set_settings,
 )
 from tssim.formatters import format_as_json, format_as_sarif
-from tssim.models.similarity import RegionSignature, SimilarRegionGroup, SimilarityResult
+from tssim.models.similarity import Region, RegionSignature, SimilarRegionGroup, SimilarityResult
 from tssim.pipeline.pipeline import run_pipeline
 
 console = Console()
@@ -92,7 +92,7 @@ def _get_group_sort_key(group: SimilarRegionGroup) -> tuple[float, float]:
     return (group.similarity, avg_lines)
 
 
-def _read_region_lines(region: "Region") -> list[str]:  # type: ignore[name-defined]
+def _read_region_lines(region: Region) -> list[str]:
     """Read lines from a file for a specific region.
 
     Args:
@@ -111,7 +111,7 @@ def _read_region_lines(region: "Region") -> list[str]:  # type: ignore[name-defi
         return []
 
 
-def _display_diff(region1: "Region", region2: "Region") -> None:  # type: ignore[name-defined]
+def _display_diff(region1: Region, region2: Region) -> None:
     """Display a unified diff between two regions.
 
     Args:


### PR DESCRIPTION
…roups

This adds a new --show-diff flag that displays unified diffs between the first two files in each similarity group when using console output format.

Key features:
- Uses Python's built-in difflib for generating unified diffs
- Leverages Rich's Syntax class with Pygments' diff lexer for colored output
- Only displays diffs for groups with 2+ regions
- Gracefully handles file read errors
- No additional dependencies required (reuses existing Rich library)

The diff output shows line-by-line differences with proper syntax highlighting, making it easy to identify what varies between similar code blocks.