### PR TITLE
Review and shorten project docstrings

### DIFF
--- a/tssim/cli.py
+++ b/tssim/cli.py
@@ -26,12 +26,7 @@ console = Console()
 
 
 def setup_logging(log_level: str) -> None:
-    """
-    Configure logging with rich handler.
-
-    Args:
-        log_level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-    """
+    """Configure logging with rich handler."""
     logging.basicConfig(
         level=log_level,
         format="%(message)s",
@@ -42,14 +37,7 @@ def setup_logging(log_level: str) -> None:
 def _group_signatures_by_file(
     signatures: list[RegionSignature],
 ) -> dict[Path, list[RegionSignature]]:
-    """Group region signatures by file path.
-
-    Args:
-        signatures: List of region signatures
-
-    Returns:
-        Dictionary mapping file paths to lists of signatures
-    """
+    """Group region signatures by file path."""
     regions_by_file: dict[Path, list[RegionSignature]] = {}
     for sig in signatures:
         path = sig.region.path
@@ -80,27 +68,13 @@ def display_processed_regions(result: SimilarityResult) -> None:
 
 
 def _get_group_sort_key(group: SimilarRegionGroup) -> tuple[float, float]:
-    """Get sort key for a similarity group.
-
-    Args:
-        group: SimilarRegionGroup to sort
-
-    Returns:
-        Tuple of (similarity, average line count)
-    """
+    """Get sort key for a similarity group by similarity and average line count."""
     avg_lines = sum(r.end_line - r.start_line + 1 for r in group.regions) / len(group.regions)
     return (group.similarity, avg_lines)
 
 
 def _read_region_lines(region: Region) -> list[str]:
-    """Read lines from a file for a specific region.
-
-    Args:
-        region: Region to read lines from
-
-    Returns:
-        List of lines from the region
-    """
+    """Read lines from a file for a specific region."""
     try:
         with open(region.path, "r", encoding="utf-8") as f:
             lines = f.readlines()
@@ -112,15 +86,7 @@ def _read_region_lines(region: Region) -> list[str]:
 
 
 def _truncate_line(line: str, max_width: int) -> str:
-    """Truncate a line to fit within max_width.
-
-    Args:
-        line: Line to truncate
-        max_width: Maximum width
-
-    Returns:
-        Truncated line if necessary, original otherwise
-    """
+    """Truncate a line to fit within max_width."""
     return line[:max_width] if len(line) > max_width else line
 
 
@@ -173,11 +139,7 @@ def _print_inserted_lines(lines2: list[str], j1: int, j2: int, col_width: int) -
 
 
 def _prepare_diff_lines(region1: Region, region2: Region) -> tuple[list[str], list[str]] | None:
-    """Read and prepare lines from both regions for diff.
-
-    Returns:
-        Tuple of (lines1, lines2) if successful, None otherwise
-    """
+    """Read and prepare lines from both regions for diff."""
     lines1 = _read_region_lines(region1)
     lines2 = _read_region_lines(region2)
 
@@ -227,12 +189,7 @@ def _process_diff_opcodes(
 
 
 def _display_diff(region1: Region, region2: Region) -> None:
-    """Display a side-by-side diff between two regions.
-
-    Args:
-        region1: First region to compare
-        region2: Second region to compare
-    """
+    """Display a side-by-side diff between two regions."""
     # Prepare lines from both regions
     prepared = _prepare_diff_lines(region1, region2)
     if prepared is None:
@@ -262,12 +219,7 @@ def _display_diff(region1: Region, region2: Region) -> None:
 
 
 def _display_group(group: SimilarRegionGroup, show_diff: bool = False) -> None:
-    """Display a single similarity group.
-
-    Args:
-        group: SimilarRegionGroup to display
-        show_diff: If True, show diff between first two regions in the group
-    """
+    """Display a single similarity group with optional diff."""
     # Display similarity group header
     console.print(f"Similar group found ([bold]{group.similarity:.1%}[/bold] similar, {group.size} regions):")
 
@@ -289,12 +241,7 @@ def _display_group(group: SimilarRegionGroup, show_diff: bool = False) -> None:
 
 
 def display_similar_groups(result: SimilarityResult, show_diff: bool = False) -> None:
-    """Display similar region groups.
-
-    Args:
-        result: Similarity result to display
-        show_diff: If True, show diff between first two regions in each group
-    """
+    """Display similar region groups with optional diff."""
     if not result.similar_groups:
         console.print("\n[yellow]No similar regions found above threshold.[/yellow]")
         return
@@ -319,12 +266,7 @@ def display_failed_files(result: SimilarityResult, show_details: bool) -> None:
 
 
 def _write_output(text: str, output_path: Path | None) -> None:
-    """Write output text to file or stdout.
-
-    Args:
-        text: The text to write
-        output_path: Path to output file, or None for stdout
-    """
+    """Write output text to file or stdout."""
     if output_path:
         output_path.write_text(text)
     else:
@@ -332,15 +274,7 @@ def _write_output(text: str, output_path: Path | None) -> None:
 
 
 def _run_pipeline_with_ui(path: Path, output_format: str) -> SimilarityResult:
-    """Run the pipeline with appropriate UI feedback based on output format.
-
-    Args:
-        path: Path to analyze
-        output_format: Output format (console, sarif)
-
-    Returns:
-        The similarity result
-    """
+    """Run the pipeline with appropriate UI feedback based on output format."""
     if output_format.lower() == "console":
         from tssim.config import get_settings
         settings = get_settings()
@@ -359,15 +293,7 @@ def _handle_output(
     log_level: str,
     show_diff: bool = False,
 ) -> None:
-    """Handle formatting and outputting results.
-
-    Args:
-        result: The similarity result
-        output_format: Output format (console, sarif)
-        output_path: Path to output file, or None for stdout
-        log_level: Logging level for debug output
-        show_diff: If True, show diff between first two regions in each group
-    """
+    """Handle formatting and outputting results."""
     if output_format.lower() == "sarif":
         output_text = format_as_sarif(result, pretty=True)
         _write_output(output_text, output_path)
@@ -378,23 +304,12 @@ def _handle_output(
 
 
 def _parse_patterns(pattern_string: str) -> list[str]:
-    """Parse comma-separated pattern string into list.
-
-    Args:
-        pattern_string: Comma-separated patterns
-
-    Returns:
-        List of stripped non-empty patterns
-    """
+    """Parse comma-separated pattern string into list."""
     return [p.strip() for p in pattern_string.split(",") if p.strip()]
 
 
 def _print_rulesets(ruleset_name: str) -> None:
-    """Print rules in the specified ruleset.
-
-    Args:
-        ruleset_name: Name of the ruleset to display (none, default, loose)
-    """
+    """Print rules in the specified ruleset."""
     from tssim.pipeline.rules_factory import get_ruleset_with_descriptions
 
     rules_with_descriptions = get_ruleset_with_descriptions(ruleset_name)
@@ -425,16 +340,7 @@ def _print_rulesets(ruleset_name: str) -> None:
 
 
 def _create_rules_settings(rules: str, rules_file: str, ruleset: str) -> RulesSettings:
-    """Create RulesSettings with proper None handling.
-
-    Args:
-        rules: Comma-separated list of rule specifications
-        rules_file: Path to file containing rule specifications
-        ruleset: Ruleset profile to use (none, default, loose)
-
-    Returns:
-        RulesSettings object
-    """
+    """Create RulesSettings with proper None handling."""
     return RulesSettings(
         ruleset=ruleset,
         rules=rules or None,
@@ -451,17 +357,7 @@ def _configure_settings(
     ignore: str,
     ignore_files: str,
 ) -> None:
-    """Configure pipeline settings.
-
-    Args:
-        rules: Comma-separated list of rule specifications
-        rules_file: Path to file containing rule specifications (one per line)
-        ruleset: Ruleset profile to use (none, default, loose)
-        threshold: LSH similarity threshold
-        min_lines: Minimum number of lines for a match
-        ignore: Comma-separated list of glob patterns to ignore files
-        ignore_files: Comma-separated list of glob patterns to find ignore files
-    """
+    """Configure pipeline settings."""
     settings = PipelineSettings(
         rules=_create_rules_settings(rules, rules_file, ruleset),
         shingle=ShingleSettings(),  # Uses default k=3
@@ -474,12 +370,7 @@ def _configure_settings(
 
 
 def _check_result_errors(result: SimilarityResult, output_format: str) -> None:
-    """Check for errors in the result and exit if necessary.
-
-    Args:
-        result: The similarity result
-        output_format: Output format (console, sarif)
-    """
+    """Check for errors in the result and exit if necessary."""
     if result.success_count == 0 and result.failure_count > 0:
         if output_format.lower() == "console":
             console.print("[bold red]Error:[/bold red] Failed to parse any files")
@@ -578,11 +469,7 @@ def main(
     ignore_files: str,
     diff: bool,
 ) -> None:
-    """
-    Analyze code similarity in PATH.
-
-    PATH can be a file or directory containing source code files.
-    """
+    """Analyze code similarity in a file or directory."""
     setup_logging(log_level.upper())
 
     # Handle --list-ruleset option

--- a/tssim/pipeline/parse.py
+++ b/tssim/pipeline/parse.py
@@ -61,15 +61,7 @@ LANGUAGE_MAP: dict[str, LanguageName] = {
 
 
 def detect_language(file_path: Path) -> LanguageName | None:
-    """
-    Detect programming language from file extension.
-
-    Args:
-        file_path: Path to the source file
-
-    Returns:
-        Language name if detected, None otherwise
-    """
+    """Detect programming language from file extension."""
     # TODO support a more robust detection mechanism (something like enry maybe or pygments)
     suffix = file_path.suffix.lower()
     return LANGUAGE_MAP.get(suffix)
@@ -102,19 +94,7 @@ def parse_source_code(source: bytes, language_name: LanguageName, file_path: Pat
 
 
 def parse_file(file_path: Path) -> ParsedFile:
-    """
-    Parse a single source file using tree-sitter.
-
-    Args:
-        file_path: Path to the source file
-
-    Returns:
-        ParsedFile object containing the AST
-
-    Raises:
-        ValueError: If language cannot be detected or file cannot be read
-        RuntimeError: If parsing fails
-    """
+    """Parse a single source file using tree-sitter."""
     logger.debug(f"Parsing file: {file_path}")
 
     language_name = detect_language(file_path)
@@ -131,14 +111,7 @@ def parse_file(file_path: Path) -> ParsedFile:
 
 
 def parse_ignore_file(ignore_file: Path) -> list[str]:
-    """Parse an ignore file and return list of patterns.
-
-    Args:
-        ignore_file: Path to the ignore file (e.g., .gitignore)
-
-    Returns:
-        List of ignore patterns (empty lines and comments are filtered out)
-    """
+    """Parse an ignore file and return list of patterns."""
     try:
         patterns = []
         with ignore_file.open("r", encoding="utf-8") as f:
@@ -169,15 +142,7 @@ def _process_ignore_file(
 
 
 def find_ignore_files(target_path: Path, ignore_file_patterns: list[str]) -> dict[Path, list[str]]:
-    """Find all ignore files in the directory hierarchy.
-
-    Args:
-        target_path: Root directory to search
-        ignore_file_patterns: Glob patterns to find ignore files
-
-    Returns:
-        Dictionary mapping directory paths to their ignore patterns
-    """
+    """Find all ignore files in the directory hierarchy."""
     ignore_files_map: dict[Path, list[str]] = {}
 
     if not target_path.is_dir():
@@ -241,16 +206,7 @@ def _match_simple_pattern(rel_path_str: str, file_name: str, pattern: str) -> bo
 
 
 def matches_pattern(file_path: Path, pattern: str, base_path: Path) -> bool:
-    """Check if a file matches an ignore pattern.
-
-    Args:
-        file_path: Path to check
-        pattern: Ignore pattern (supports glob patterns)
-        base_path: Base directory for relative pattern matching
-
-    Returns:
-        True if the file matches the pattern
-    """
+    """Check if a file matches an ignore pattern."""
     if pattern.startswith("!"):
         return False
 
@@ -316,17 +272,7 @@ def should_ignore_file(
     ignore_patterns: list[str],
     ignore_files_map: dict[Path, list[str]],
 ) -> bool:
-    """Check if a file should be ignored based on patterns.
-
-    Args:
-        file_path: File to check
-        target_path: Root directory being analyzed
-        ignore_patterns: Direct ignore patterns from CLI
-        ignore_files_map: Map of directory to ignore patterns from ignore files
-
-    Returns:
-        True if the file should be ignored
-    """
+    """Check if a file should be ignored based on patterns."""
     # Check direct ignore patterns from CLI
     for pattern in ignore_patterns:
         if matches_pattern(file_path, pattern, target_path):
@@ -368,7 +314,7 @@ def _collect_directory_files(
 
 
 def collect_source_files(target_path: Path) -> list[Path]:
-    """Collect all source files from a path, applying ignore patterns."""
+    """Collect all source files from a path with ignore patterns applied."""
     settings = get_settings()
     ignore_patterns = settings.ignore_patterns
     ignore_file_patterns = settings.ignore_file_patterns
@@ -394,15 +340,7 @@ def parse_files(files: list[Path], result: ParseResult) -> None:
 
 
 def parse_path(target_path: Path) -> ParseResult:
-    """
-    Parse a file or directory of source files.
-
-    Args:
-        target_path: Path to a file or directory to parse
-
-    Returns:
-        ParseResult containing all parsed files and any failures
-    """
+    """Parse a file or directory of source files."""
     logger.info(f"Starting parse of: {target_path}")
 
     result = ParseResult()

--- a/tssim/pipeline/pipeline.py
+++ b/tssim/pipeline/pipeline.py
@@ -28,11 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 def _run_parse_stage(target_path: Path) -> ParseResult:
-    """Run parsing stage.
-
-    Returns:
-        Parse result with parsed files and failures
-    """
+    """Run parsing stage."""
     logger.info("Stage 1/5: Parsing...")
     parse_result = parse_path(target_path)
     logger.info(
@@ -46,15 +42,7 @@ def _run_parse_stage(target_path: Path) -> ParseResult:
 def _run_extract_stage(
     parsed_files: list[ParsedFile], include_sections: bool = True
 ) -> list[ExtractedRegion]:
-    """Run region extraction stage.
-
-    Args:
-        parsed_files: List of parsed source files
-        include_sections: If True, create section regions for non-target code
-
-    Returns:
-        List of extracted regions
-    """
+    """Run region extraction stage."""
     logger.info("Stage 2/5: Extracting regions...")
     extracted_regions = extract_all_regions(parsed_files, include_sections)
     logger.info("Extracted %d region(s) from %d file(s)", len(extracted_regions), len(parsed_files))
@@ -64,15 +52,7 @@ def _run_extract_stage(
 def _filter_groups_by_min_lines(
     groups: list[SimilarRegionGroup], min_lines: int
 ) -> list[SimilarRegionGroup]:
-    """Filter similar groups to only include those with at least min_lines in all regions.
-
-    Args:
-        groups: List of similar region groups
-        min_lines: Minimum number of lines for a match
-
-    Returns:
-        Filtered list of groups
-    """
+    """Filter similar groups to only include those meeting the minimum line count in all regions."""
     filtered = []
     for group in groups:
         # Check if all regions meet the min_lines threshold
@@ -93,15 +73,7 @@ def _filter_groups_by_min_lines(
 def _filter_pairs_by_min_lines(
     pairs: list[SimilarRegionPair], min_lines: int
 ) -> list[SimilarRegionPair]:
-    """Filter similar pairs to only include those with at least min_lines.
-
-    Args:
-        pairs: List of similar region pairs
-        min_lines: Minimum number of lines for a match
-
-    Returns:
-        Filtered list of pairs
-    """
+    """Filter similar pairs to only include those meeting the minimum line count."""
     filtered = []
     for pair in pairs:
         lines1 = pair.region1.end_line - pair.region1.start_line + 1
@@ -124,14 +96,7 @@ def _filter_pairs_by_min_lines(
 
 
 def _get_matched_regions_from_groups(groups: list[SimilarRegionGroup]) -> list[Region]:
-    """Extract all matched regions from similar groups.
-
-    Args:
-        groups: List of similar region groups
-
-    Returns:
-        List of all regions that were matched
-    """
+    """Extract all matched regions from similar groups."""
     matched_regions: list[Region] = []
     for group in groups:
         matched_regions.extend(group.regions)
@@ -144,11 +109,7 @@ def _run_shingle_stage(
     rule_engine: RuleEngine,
     settings: PipelineSettings,
 ) -> list[ShingledRegion]:
-    """Run shingling stage.
-
-    Returns:
-        List of shingled regions
-    """
+    """Run shingling stage."""
     logger.info("Stage 3/5: Shingling regions (with rules)...")
     shingled_regions = shingle_regions(
         extracted_regions,
@@ -161,11 +122,7 @@ def _run_shingle_stage(
 
 
 def _run_minhash_stage(shingled_regions: list[ShingledRegion], num_perm: int) -> list[RegionSignature]:
-    """Run MinHash signature computation stage.
-
-    Returns:
-        List of region signatures
-    """
+    """Run MinHash signature computation stage."""
     logger.info("Stage 4/5: Computing MinHash signatures...")
     signatures = compute_region_signatures(shingled_regions, num_perm=num_perm)
     logger.info("Created %d signature(s)", len(signatures))
@@ -178,11 +135,7 @@ def _run_lsh_stage(
     threshold: float,
     failed_files: dict[Path, str],
 ) -> SimilarityResult:
-    """Run LSH similarity detection stage.
-
-    Returns:
-        SimilarityResult with similar pairs
-    """
+    """Run LSH similarity detection stage."""
     logger.info("Stage 5/5: Finding similar pairs...")
     similarity_result = detect_similarity(
         signatures,
@@ -204,16 +157,7 @@ def _run_level1_matching(
     rule_engine: RuleEngine,
     settings: PipelineSettings,
 ) -> tuple[list[SimilarRegionGroup], list[RegionSignature]]:
-    """Run Level 1: Region-Level Matching (functions/classes).
-
-    Args:
-        parsed_files: List of parsed source files
-        rule_engine: Rule engine for applying transformation rules
-        settings: Pipeline settings
-
-    Returns:
-        Tuple of (filtered groups, signatures)
-    """
+    """Run Level 1 region-level matching for functions and classes."""
     logger.info("===== LEVEL 1: Region-Level Matching =====")
 
     # Extract only functions/classes (no section regions)
@@ -248,17 +192,7 @@ def _run_level2_matching(
     rule_engine: RuleEngine,
     settings: PipelineSettings,
 ) -> tuple[list[SimilarRegionGroup], list[RegionSignature]]:
-    """Run Level 2: Line-Level Matching (unmatched sections).
-
-    Args:
-        parsed_files: List of parsed source files
-        level1_filtered_groups: Filtered groups from Level 1
-        rule_engine: Rule engine for applying transformation rules
-        settings: Pipeline settings
-
-    Returns:
-        Tuple of (filtered groups, signatures)
-    """
+    """Run Level 2 line-level matching for unmatched sections."""
     logger.info("===== LEVEL 2: Line-Level Matching =====")
 
     # Track matched lines from level 1
@@ -291,7 +225,7 @@ def _run_level2_matching(
 
 
 def run_pipeline(target_path: str | Path) -> SimilarityResult:
-    """Run the full two-level pipeline on a target path. """
+    """Run the full two-level pipeline on a target path."""
     settings = get_settings()
     logger.info("Starting two-level pipeline for: %s (min_lines=%d)", target_path, settings.lsh.min_lines)
 

--- a/tssim/pipeline/region_extraction.py
+++ b/tssim/pipeline/region_extraction.py
@@ -69,15 +69,7 @@ LANGUAGE_REGION_MAPPINGS["jsx"] = LANGUAGE_REGION_MAPPINGS["javascript"]
 
 
 def _extract_node_name(node: Node, source: bytes) -> str:
-    """Extract the name of a function/class/method from its node.
-
-    Args:
-        node: The function_definition or class_definition node
-        source: Source code bytes
-
-    Returns:
-        The extracted name or 'anonymous' if not found
-    """
+    """Extract the name of a function/class/method from its node."""
     # Look for 'name' or 'identifier' child node
     for child in node.children:
         if child.type in ("identifier", "name"):
@@ -86,14 +78,7 @@ def _extract_node_name(node: Node, source: bytes) -> str:
 
 
 def _collect_top_level_nodes(root_node: Node) -> list[Node]:
-    """Collect all top-level nodes that are direct children of the root.
-
-    Args:
-        root_node: The root node of the AST
-
-    Returns:
-        List of top-level nodes (direct children)
-    """
+    """Collect all top-level nodes that are direct children of the root."""
     # For most languages, the root is a "program" or "module" node
     # We want its direct children as top-level nodes
     if root_node.type in ("module", "program", "source_file"):
@@ -102,19 +87,7 @@ def _collect_top_level_nodes(root_node: Node) -> list[Node]:
 
 
 def _collect_all_matching_nodes(root_node: Node, target_types: set[str]) -> list[Node]:
-    """Recursively collect all nodes matching target types from the AST.
-
-    This function performs a depth-first traversal of the AST to find ALL nodes
-    that match the target types, not just top-level ones. This allows extraction
-    of nested functions, methods within classes, etc.
-
-    Args:
-        root_node: The root node to start traversal from
-        target_types: Set of node types to collect
-
-    Returns:
-        List of all nodes matching target types (in depth-first order)
-    """
+    """Recursively collect all nodes matching target types from the AST using depth-first traversal."""
     matching_nodes: list[Node] = []
 
     def traverse(node: Node) -> None:
@@ -134,15 +107,7 @@ def _create_section_region(
     pending_nodes: list[Node],
     parsed_file: ParsedFile,
 ) -> ExtractedRegion:
-    """Create a section region from a list of pending nodes.
-
-    Args:
-        pending_nodes: List of nodes to group into a section
-        parsed_file: The parsed file for context
-
-    Returns:
-        ExtractedRegion for the section
-    """
+    """Create a section region from a list of pending nodes."""
     first_node = pending_nodes[0]
     last_node = pending_nodes[-1]
     start_line = first_node.start_point[0] + 1
@@ -163,15 +128,7 @@ def _create_section_region(
 
 
 def _get_region_type_for_node(node_type: str, language: str) -> str:
-    """Get the region type label for a node type.
-
-    Args:
-        node_type: The AST node type
-        language: Programming language
-
-    Returns:
-        Region type label (e.g., "function", "class")
-    """
+    """Get the region type label for a node type."""
     mappings = LANGUAGE_REGION_MAPPINGS.get(language, [])
     for mapping in mappings:
         if node_type in mapping.types:
@@ -183,15 +140,7 @@ def _create_target_region(
     node: Node,
     parsed_file: ParsedFile,
 ) -> ExtractedRegion:
-    """Create a region for a target node (function, class, etc).
-
-    Args:
-        node: The AST node
-        parsed_file: The parsed file for context
-
-    Returns:
-        ExtractedRegion for the target node
-    """
+    """Create a region for a target node such as a function or class."""
     name = _extract_node_name(node, parsed_file.source)
     region_type = _get_region_type_for_node(node.type, parsed_file.language)
 
@@ -252,20 +201,7 @@ def _partition_by_type(
     parsed_file: ParsedFile,
     include_sections: bool = True,
 ) -> list[ExtractedRegion]:
-    """Partition nodes into regions.
-
-    When include_sections is False, only extract target regions.
-    When include_sections is True, also group non-target nodes into sections.
-
-    Args:
-        nodes: List of top-level nodes to partition
-        target_types: Set of node types to extract as named regions
-        parsed_file: The parsed file for context
-        include_sections: If True, create section regions for non-target nodes
-
-    Returns:
-        List of extracted regions
-    """
+    """Partition nodes into target regions and optional section regions for non-target nodes."""
     if not include_sections:
         return [_create_target_region(node, parsed_file) for node in nodes if node.type in target_types]
 
@@ -273,25 +209,7 @@ def _partition_by_type(
 
 
 def extract_regions(parsed_file: ParsedFile, include_sections: bool = True) -> list[ExtractedRegion]:
-    """Extract code regions from a parsed file.
-
-    Uses language-specific mappings to partition the file into regions.
-
-    When include_sections is True: Extracts top-level nodes and creates section
-    regions for code that doesn't match target types (original behavior).
-
-    When include_sections is False: Recursively extracts ALL matching nodes
-    (functions, methods, classes, nested functions, etc.) without sections.
-    This allows matching individual methods even when their containing classes differ.
-
-    Args:
-        parsed_file: Parsed source file
-        include_sections: If True, use top-level extraction with sections.
-                         If False, use recursive extraction without sections.
-
-    Returns:
-        List of extracted regions with their AST nodes
-    """
+    """Extract code regions from a parsed file using language-specific mappings."""
     logger.info("Extracting regions from %s (%s)", parsed_file.path, parsed_file.language)
 
     # Check if language has region mappings
@@ -333,15 +251,7 @@ def extract_regions(parsed_file: ParsedFile, include_sections: bool = True) -> l
 def extract_all_regions(
     parsed_files: list[ParsedFile], include_sections: bool = True
 ) -> list[ExtractedRegion]:
-    """Extract regions from all parsed files.
-
-    Args:
-        parsed_files: List of parsed source files
-        include_sections: If True, create section regions for non-target code
-
-    Returns:
-        List of all extracted regions
-    """
+    """Extract regions from all parsed files."""
     all_regions: list[ExtractedRegion] = []
 
     for parsed_file in parsed_files:
@@ -356,14 +266,7 @@ def extract_all_regions(
 
 
 def get_matched_line_ranges(matched_regions: list[Region]) -> dict[Path, set[int]]:
-    """Get the line ranges that were matched, organized by file path.
-
-    Args:
-        matched_regions: List of regions that were matched
-
-    Returns:
-        Dictionary mapping file paths to sets of matched line numbers
-    """
+    """Get the line ranges that were matched, organized by file path."""
     matched_lines_by_file: dict[Path, set[int]] = {}
 
     for region in matched_regions:
@@ -388,15 +291,7 @@ def _finish_range(
 def _find_unmatched_ranges(
     matched_lines: set[int], file_end_line: int
 ) -> list[tuple[int, int]]:
-    """Find contiguous ranges of unmatched lines in a file.
-
-    Args:
-        matched_lines: Set of line numbers that are already matched
-        file_end_line: Last line number in the file
-
-    Returns:
-        List of (start_line, end_line) tuples for unmatched ranges
-    """
+    """Find contiguous ranges of unmatched lines in a file."""
     unmatched_ranges: list[tuple[int, int]] = []
     range_start = None
 
@@ -414,16 +309,7 @@ def _find_unmatched_ranges(
 def _create_line_region(
     parsed_file: ParsedFile, start_line: int, end_line: int
 ) -> ExtractedRegion:
-    """Create a line-based region for a range of lines.
-
-    Args:
-        parsed_file: The parsed file
-        start_line: Start line of the region
-        end_line: End line of the region
-
-    Returns:
-        ExtractedRegion for the line range
-    """
+    """Create a line-based region for a range of lines."""
     region = Region(
         path=parsed_file.path,
         language=parsed_file.language,
@@ -444,16 +330,7 @@ def create_line_based_regions(
     matched_lines_by_file: dict[Path, set[int]],
     min_lines: int,
 ) -> list[ExtractedRegion]:
-    """Create line-based regions for unmatched sections of files.
-
-    Args:
-        parsed_files: List of parsed source files
-        matched_lines_by_file: Dictionary mapping file paths to sets of matched line numbers
-        min_lines: Minimum number of lines for a region to be created
-
-    Returns:
-        List of line-based regions for unmatched sections
-    """
+    """Create line-based regions for unmatched sections of files."""
     line_regions: list[ExtractedRegion] = []
 
     for parsed_file in parsed_files:

--- a/tssim/pipeline/rules/engine.py
+++ b/tssim/pipeline/rules/engine.py
@@ -10,19 +10,10 @@ from .parser import parse_rule
 
 
 class RuleEngine:
-    """
-    Engine for applying rules to syntax tree nodes.
-
-    Replaces the normalizer system with a more flexible rule-based approach.
-    """
+    """Engine for applying rules to syntax tree nodes."""
 
     def __init__(self, rules: list[Rule]):
-        """
-        Initialize the rule engine with a list of rules.
-
-        Args:
-            rules: List of rules to apply (last rule wins for conflicts)
-        """
+        """Initialize the rule engine with a list of rules."""
         self.rules = rules
         self._identifier_counters: dict[str, int] = {}
         self._operation_handlers = self._build_operation_handlers()
@@ -95,20 +86,7 @@ class RuleEngine:
     def apply_rules(
         self, node: Node, language: str, node_name: Optional[str] = None
     ) -> tuple[Optional[str], Optional[str]]:
-        """
-        Apply all matching rules to a node.
-
-        Args:
-            node: The syntax tree node
-            language: The language of the source code
-            node_name: Optional override for node type name
-
-        Returns:
-            Tuple of (name, value) where either can be None
-
-        Raises:
-            SkipNodeException: If a skip rule matches this node
-        """
+        """Apply all matching rules to a node."""
         node_type = node_name or node.type
         name = None
         value = None
@@ -120,7 +98,7 @@ class RuleEngine:
         return name, value
 
     def reset_identifiers(self) -> None:
-        """Reset the identifier counter (useful between files)."""
+        """Reset the identifier counter."""
         self._identifier_counters.clear()
 
 

--- a/tssim/pipeline/rules/models.py
+++ b/tssim/pipeline/rules/models.py
@@ -17,17 +17,7 @@ class RuleOperation(Enum):
 
 @dataclass
 class Rule:
-    """
-    Represents a single rule that can be applied to syntax tree nodes.
-
-    Rules follow the format:
-    <lang|*> : <op> : nodes=<node1|node2|glob*> [,:k=v ...]
-
-    Examples:
-        python:skip:nodes=import_statement|import_from_statement
-        python:replace_value:nodes=string|integer|float,value=<LIT>
-        *:anonymize_identifiers:nodes=identifier,scheme=flat,prefix=VAR
-    """
+    """Represents a single rule that can be applied to syntax tree nodes."""
 
     language: str  # Language name or "*" for all languages
     operation: RuleOperation
@@ -47,7 +37,7 @@ class Rule:
 
     @staticmethod
     def _matches_pattern(node_type: str, pattern: str) -> bool:
-        """Check if a node type matches a pattern (supports * wildcard at end)."""
+        """Check if a node type matches a pattern with wildcard support."""
         if pattern == node_type:
             return True
         if pattern.endswith("*"):
@@ -58,21 +48,13 @@ class Rule:
 
 @dataclass
 class RuleResult:
-    """
-    Result of applying a rule to a node.
-
-    Similar to NormalizationResult but for rules.
-    """
+    """Result of applying a rule to a node."""
 
     name: Optional[str] = None  # New name for the node
     value: Optional[str] = None  # New value for the node
 
 
 class SkipNodeException(Exception):
-    """
-    Exception raised when a rule indicates a node should be skipped.
-
-    Similar to SkipNode from normalizers.
-    """
+    """Exception raised when a rule indicates a node should be skipped."""
 
     pass

--- a/tssim/pipeline/shingle.py
+++ b/tssim/pipeline/shingle.py
@@ -103,11 +103,7 @@ class ASTShingler:
         language: str,
         source: bytes,
     ) -> tuple[str, str | None]:
-        """Apply rules to a node and return the modified name and value.
-
-        Raises:
-            SkipNodeException: If a skip rule matches this node
-        """
+        """Apply rules to a node and return the modified name and value."""
         rule_name, rule_value = self.rule_engine.apply_rules(node, language, name)
         if rule_name is not None:
             name = rule_name
@@ -121,11 +117,7 @@ class ASTShingler:
         language: str,
         source: bytes,
     ) -> NodeRepresentation:
-        """Get the representation of a node with rules applied.
-
-        Raises:
-            SkipNodeException: If a skip rule matches this node (converted to SkipNode for compatibility)
-        """
+        """Get the representation of a node with rules applied."""
         name = node.type
         value = self._extract_node_value(node, source)
         try:

--- a/tssim/pipeline/verification.py
+++ b/tssim/pipeline/verification.py
@@ -19,15 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def _compute_lcs_length(shingles1: list[str], shingles2: list[str]) -> int:
-    """Compute longest common subsequence length using dynamic programming.
-
-    Args:
-        shingles1: First list of shingles
-        shingles2: Second list of shingles
-
-    Returns:
-        Length of longest common subsequence
-    """
+    """Compute longest common subsequence length using dynamic programming."""
     m, n = len(shingles1), len(shingles2)
     dp = [[0] * (n + 1) for _ in range(m + 1)]
 
@@ -42,34 +34,13 @@ def _compute_lcs_length(shingles1: list[str], shingles2: list[str]) -> int:
 
 
 def _normalize_similarity(lcs_length: int, len1: int, len2: int) -> float:
-    """Normalize LCS length to similarity score.
-
-    Args:
-        lcs_length: Length of longest common subsequence
-        len1: Length of first sequence
-        len2: Length of second sequence
-
-    Returns:
-        Normalized similarity score between 0.0 and 1.0
-    """
+    """Normalize LCS length to similarity score."""
     avg_length = (len1 + len2) / 2
     return lcs_length / avg_length if avg_length > 0 else 0.0
 
 
 def _compute_ordered_similarity(shingles1: list[str], shingles2: list[str]) -> float:
-    """Compute order-sensitive similarity between two shingle lists.
-
-    Uses longest common subsequence (LCS) to measure similarity while
-    accounting for order. This is more accurate than set-based Jaccard
-    for detecting when code blocks appear in different order.
-
-    Args:
-        shingles1: First list of shingles
-        shingles2: Second list of shingles
-
-    Returns:
-        Similarity score between 0.0 and 1.0
-    """
+    """Compute order-sensitive similarity between two shingle lists using LCS."""
     if not shingles1 or not shingles2:
         return 0.0
 
@@ -80,14 +51,7 @@ def _compute_ordered_similarity(shingles1: list[str], shingles2: list[str]) -> f
 def _build_region_lookup(
     shingled_regions: list[ShingledRegion],
 ) -> dict[Path, dict[int, ShingledRegion]]:
-    """Build lookup map from region path and start line to shingled region.
-
-    Args:
-        shingled_regions: List of shingled regions
-
-    Returns:
-        Nested dict mapping path -> start_line -> shingled region
-    """
+    """Build lookup map from region path and start line to shingled region."""
     region_to_shingled: dict[Path, dict[int, ShingledRegion]] = {}
     for sr in shingled_regions:
         if sr.region.path not in region_to_shingled:
@@ -100,15 +64,7 @@ def _verify_single_pair(
     pair: SimilarRegionPair,
     region_lookup: dict[Path, dict[int, ShingledRegion]],
 ) -> SimilarRegionPair:
-    """Verify a single candidate pair using order-sensitive similarity.
-
-    Args:
-        pair: Candidate similar pair
-        region_lookup: Lookup map for shingled regions
-
-    Returns:
-        Verified pair with updated similarity score
-    """
+    """Verify a single candidate pair using order-sensitive similarity."""
     sr1 = region_lookup.get(pair.region1.path, {}).get(pair.region1.start_line)
     sr2 = region_lookup.get(pair.region2.path, {}).get(pair.region2.start_line)
 
@@ -144,18 +100,7 @@ def verify_similar_pairs(
     pairs: list[SimilarRegionPair],
     shingled_regions: list[ShingledRegion],
 ) -> list[SimilarRegionPair]:
-    """Verify candidate pairs using order-sensitive similarity.
-
-    Recomputes similarity for each candidate pair using ordered shingle comparison,
-    which accounts for the sequence of code patterns rather than just their presence.
-
-    Args:
-        pairs: Candidate similar pairs from LSH
-        shingled_regions: Shingled regions for lookup
-
-    Returns:
-        Verified pairs with updated similarity scores
-    """
+    """Verify candidate pairs using order-sensitive similarity."""
     logger.info("Verifying %d candidate pair(s) with order-sensitive similarity", len(pairs))
 
     region_lookup = _build_region_lookup(shingled_regions)


### PR DESCRIPTION
Simplified all docstrings throughout the project to follow a consistent format with just a brief description and supporting details when needed. Removed verbose Args and Returns sections that duplicated information already clear from type hints.

Changes:
- Updated function and class docstrings to be concise one-liners
- Removed redundant Args/Returns/Raises sections
- Kept only essential context where behavior is not obvious
- Maintained clarity while reducing verbosity

All tests pass and code quality checks succeed.