### PR TITLE
Detect background color in diff mode CLI

### DIFF
--- a/tssim/diff.py
+++ b/tssim/diff.py
@@ -6,8 +6,12 @@ from collections.abc import Sequence
 from rich.console import Console
 
 from tssim.models.similarity import Region
+from tssim.terminal_detect import get_diff_colors
 
 console = Console()
+
+# Get colors based on terminal background
+_colors = get_diff_colors()
 
 
 def _truncate_line(line: str, max_width: int) -> str:
@@ -79,18 +83,13 @@ def _highlight_char_diff(text1: str, text2: str, col_width: int) -> tuple[str, s
 
     Returns (left_highlighted, right_highlighted) with full-width backgrounds.
     """
-    soft_left_bg = "on rgb(255,235,235)"
-    soft_right_bg = "on rgb(235,255,235)"
-    bright_left_style = "bold rgb(220,0,0)"
-    bright_right_style = "bold rgb(0,180,0)"
-
     matcher = difflib.SequenceMatcher(None, text1, text2)
     result_left = []
     result_right = []
 
     for tag, i1, i2, j1, j2 in matcher.get_opcodes():
         left_styled, right_styled = _process_diff_opcode(
-            tag, text1[i1:i2], text2[j1:j2], bright_left_style, bright_right_style
+            tag, text1[i1:i2], text2[j1:j2], _colors.left_fg, _colors.right_fg
         )
         if left_styled:
             result_left.append(left_styled)
@@ -103,8 +102,8 @@ def _highlight_char_diff(text1: str, text2: str, col_width: int) -> tuple[str, s
     right_padding = col_width - len(text2)
 
     return (
-        f"[{soft_left_bg}]{left_text}{' ' * left_padding}[/{soft_left_bg}]",
-        f"[{soft_right_bg}]{right_text}{' ' * right_padding}[/{soft_right_bg}]"
+        f"[{_colors.left_bg}]{left_text}{' ' * left_padding}[/{_colors.left_bg}]",
+        f"[{_colors.right_bg}]{right_text}{' ' * right_padding}[/{_colors.right_bg}]"
     )
 
 
@@ -122,14 +121,14 @@ def _print_replaced_lines(lines1: list[str], lines2: list[str], i1: int, i2: int
             else:
                 # No corresponding right line - just soft background full width
                 padding = col_width - len(left_line)
-                left = f"[on rgb(255,235,235)]{left_line}{' ' * padding}[/on rgb(255,235,235)]"
-                right = f"[on rgb(235,255,235)]{' ' * col_width}[/on rgb(235,255,235)]"
+                left = f"[{_colors.left_bg}]{left_line}{' ' * padding}[/{_colors.left_bg}]"
+                right = f"[{_colors.right_bg}]{' ' * col_width}[/{_colors.right_bg}]"
         else:
             # No left line, only right
             right_line = _truncate_line(lines2[j1 + idx], col_width)
             padding = col_width - len(right_line)
-            left = f"[on rgb(255,235,235)]{' ' * col_width}[/on rgb(255,235,235)]"
-            right = f"[on rgb(235,255,235)]{right_line}{' ' * padding}[/on rgb(235,255,235)]"
+            left = f"[{_colors.left_bg}]{' ' * col_width}[/{_colors.left_bg}]"
+            right = f"[{_colors.right_bg}]{right_line}{' ' * padding}[/{_colors.right_bg}]"
 
         console.print(f"  {left} │ {right}")
 
@@ -140,7 +139,7 @@ def _print_deleted_lines(lines1: list[str], i1: int, i2: int, col_width: int) ->
         left_line = _truncate_line(lines1[i], col_width)
         # Use soft red background for full width
         padding = col_width - len(left_line)
-        left = f"[on rgb(255,235,235)]{left_line}{' ' * padding}[/on rgb(255,235,235)]"
+        left = f"[{_colors.left_bg}]{left_line}{' ' * padding}[/{_colors.left_bg}]"
         console.print(f"  {left} │ {' ' * col_width}")
 
 
@@ -150,7 +149,7 @@ def _print_inserted_lines(lines2: list[str], j1: int, j2: int, col_width: int) -
         right_line = _truncate_line(lines2[j], col_width)
         # Use soft green background for full width
         padding = col_width - len(right_line)
-        right = f"[on rgb(235,255,235)]{right_line}{' ' * padding}[/on rgb(235,255,235)]"
+        right = f"[{_colors.right_bg}]{right_line}{' ' * padding}[/{_colors.right_bg}]"
         console.print(f"  {' ' * col_width} │ {right}")
 
 

--- a/tssim/terminal_detect.py
+++ b/tssim/terminal_detect.py
@@ -21,18 +21,40 @@ def _calculate_luminance(r: int, g: int, b: int) -> float:
     Returns a value between 0 (black) and 1 (white).
     """
     # Normalize to 0-1
-    r, g, b = r / 255.0, g / 255.0, b / 255.0
+    r_norm = r / 255.0
+    g_norm = g / 255.0
+    b_norm = b / 255.0
 
     # Apply sRGB gamma correction
     def correct(c: float) -> float:
         if c <= 0.03928:
             return c / 12.92
-        return ((c + 0.055) / 1.055) ** 2.4
+        result: float = ((c + 0.055) / 1.055) ** 2.4
+        return result
 
-    r, g, b = correct(r), correct(g), correct(b)
+    r_corrected = correct(r_norm)
+    g_corrected = correct(g_norm)
+    b_corrected = correct(b_norm)
 
     # Calculate luminance
-    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+    return 0.2126 * r_corrected + 0.7152 * g_corrected + 0.0722 * b_corrected
+
+
+def _extract_rgb_part(response: str) -> str | None:
+    """Extract RGB part from OSC 11 response."""
+    if 'rgb:' not in response:
+        return None
+    rgb_part = response.split('rgb:')[1]
+    # Remove any escape sequences or terminators
+    return rgb_part.split('\033')[0].split('\007')[0]
+
+
+def _parse_hex_component(hex_str: str) -> int:
+    """Parse a hex color component to 0-255 range."""
+    # Values are typically 16-bit (0000-FFFF), we need 8-bit (00-FF)
+    if len(hex_str) >= 2:
+        return int(hex_str[:2], 16)
+    return int(hex_str, 16)
 
 
 def _parse_osc11_response(response: str) -> tuple[int, int, int] | None:
@@ -42,29 +64,72 @@ def _parse_osc11_response(response: str) -> tuple[int, int, int] | None:
     or variants with different terminators.
     """
     try:
-        # Look for rgb: pattern
-        if 'rgb:' not in response:
+        rgb_part = _extract_rgb_part(response)
+        if not rgb_part:
             return None
-
-        # Extract the RGB part
-        rgb_part = response.split('rgb:')[1]
-        # Remove any escape sequences or terminators
-        rgb_part = rgb_part.split('\033')[0].split('\007')[0]
 
         # Parse RGB values (format is typically RRRR/GGGG/BBBB in hex)
         parts = rgb_part.split('/')
         if len(parts) != 3:
             return None
 
-        # Convert from hex to 0-255 range
-        # Values are typically 16-bit (0000-FFFF), we need 8-bit (00-FF)
-        r = int(parts[0][:2], 16) if len(parts[0]) >= 2 else int(parts[0], 16)
-        g = int(parts[1][:2], 16) if len(parts[1]) >= 2 else int(parts[1], 16)
-        b = int(parts[2][:2], 16) if len(parts[2]) >= 2 else int(parts[2], 16)
+        r = _parse_hex_component(parts[0])
+        g = _parse_hex_component(parts[1])
+        b = _parse_hex_component(parts[2])
 
         return (r, g, b)
     except (ValueError, IndexError):
         return None
+
+
+def _is_response_complete(response: str, max_length: int) -> bool:
+    """Check if terminal response is complete."""
+    if response.endswith('\033\\') or response.endswith('\007'):
+        return True
+    if len(response) >= max_length:
+        return True
+    return False
+
+
+def _read_terminal_response(timeout: float = 0.1, max_length: int = 100) -> str:
+    """Read response from terminal with timeout.
+
+    Args:
+        timeout: Maximum time to wait for response in seconds
+        max_length: Maximum response length to read
+
+    Returns:
+        The terminal response string
+    """
+    response = ""
+    while True:
+        # Check if data is available
+        ready, _, _ = select.select([sys.stdin], [], [], timeout)
+        if not ready:
+            break
+
+        char = sys.stdin.read(1)
+        response += char
+
+        if _is_response_complete(response, max_length):
+            break
+
+    return response
+
+
+def _rgb_to_background_mode(rgb: tuple[int, int, int]) -> BackgroundMode:
+    """Convert RGB values to background mode based on luminance."""
+    r, g, b = rgb
+    luminance = _calculate_luminance(r, g, b)
+    # Threshold: > 0.5 is light, <= 0.5 is dark
+    return BackgroundMode.LIGHT if luminance > 0.5 else BackgroundMode.DARK
+
+
+def _query_terminal_background() -> str:
+    """Query terminal for background color using OSC 11."""
+    sys.stdout.write('\033]11;?\033\\')
+    sys.stdout.flush()
+    return _read_terminal_response()
 
 
 def _detect_via_osc11() -> BackgroundMode:
@@ -85,39 +150,13 @@ def _detect_via_osc11() -> BackgroundMode:
             # Set terminal to raw mode to read response
             tty.setraw(sys.stdin.fileno())
 
-            # Send OSC 11 query
-            sys.stdout.write('\033]11;?\033\\')
-            sys.stdout.flush()
+            # Query terminal and read response
+            response = _query_terminal_background()
 
-            # Wait for response with timeout (100ms)
-            response = ""
-            timeout = 0.1
-
-            while True:
-                # Check if data is available
-                ready, _, _ = select.select([sys.stdin], [], [], timeout)
-                if not ready:
-                    break
-
-                char = sys.stdin.read(1)
-                response += char
-
-                # Check for end of response (either \033\\ or \007)
-                if response.endswith('\033\\') or response.endswith('\007'):
-                    break
-
-                # Safety: don't read forever
-                if len(response) > 100:
-                    break
-
-            # Parse the response
+            # Parse and convert to mode
             rgb = _parse_osc11_response(response)
             if rgb:
-                r, g, b = rgb
-                luminance = _calculate_luminance(r, g, b)
-
-                # Threshold: > 0.5 is light, <= 0.5 is dark
-                return BackgroundMode.LIGHT if luminance > 0.5 else BackgroundMode.DARK
+                return _rgb_to_background_mode(rgb)
 
             return BackgroundMode.UNKNOWN
 
@@ -128,6 +167,29 @@ def _detect_via_osc11() -> BackgroundMode:
     except (OSError, termios.error):
         # Terminal control not available (e.g., in tests, pipes, etc.)
         return BackgroundMode.UNKNOWN
+
+
+def _interpret_color_code(bg_code: int) -> BackgroundMode:
+    """Interpret ANSI color code to determine background mode.
+
+    Args:
+        bg_code: ANSI color code (0-15 typically)
+
+    Returns:
+        BackgroundMode based on color code brightness
+    """
+    # 0: black (dark)
+    # 7: white/light gray (light)
+    # 15: bright white (light)
+    # 8-15: bright colors (light background)
+    # 0-7: dark colors (dark background)
+    if bg_code == 0:
+        return BackgroundMode.DARK
+    if bg_code in (7, 15):
+        return BackgroundMode.LIGHT
+    if bg_code >= 8:
+        return BackgroundMode.LIGHT
+    return BackgroundMode.DARK
 
 
 def _detect_via_colorfgbg() -> BackgroundMode:
@@ -147,20 +209,7 @@ def _detect_via_colorfgbg() -> BackgroundMode:
             return BackgroundMode.UNKNOWN
 
         bg_code = int(parts[-1])  # Background is the last part
-
-        # Typically:
-        # 0-7: dark colors (black, red, green, yellow, blue, magenta, cyan, white)
-        # 8-15: bright versions (light background)
-        # 15 is often white, 0 is black
-
-        if bg_code == 0:  # Black
-            return BackgroundMode.DARK
-        elif bg_code == 15 or bg_code == 7:  # White or light gray
-            return BackgroundMode.LIGHT
-        elif bg_code >= 8:  # Bright colors
-            return BackgroundMode.LIGHT
-        else:  # Dark colors
-            return BackgroundMode.DARK
+        return _interpret_color_code(bg_code)
 
     except (ValueError, IndexError):
         return BackgroundMode.UNKNOWN

--- a/tssim/terminal_detect.py
+++ b/tssim/terminal_detect.py
@@ -1,0 +1,246 @@
+"""Terminal background color detection utilities."""
+
+import os
+import sys
+import select
+import termios
+import tty
+from enum import Enum
+
+
+class BackgroundMode(Enum):
+    """Terminal background mode."""
+    LIGHT = "light"
+    DARK = "dark"
+    UNKNOWN = "unknown"
+
+
+def _calculate_luminance(r: int, g: int, b: int) -> float:
+    """Calculate relative luminance using sRGB formula.
+
+    Returns a value between 0 (black) and 1 (white).
+    """
+    # Normalize to 0-1
+    r, g, b = r / 255.0, g / 255.0, b / 255.0
+
+    # Apply sRGB gamma correction
+    def correct(c: float) -> float:
+        if c <= 0.03928:
+            return c / 12.92
+        return ((c + 0.055) / 1.055) ** 2.4
+
+    r, g, b = correct(r), correct(g), correct(b)
+
+    # Calculate luminance
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _parse_osc11_response(response: str) -> tuple[int, int, int] | None:
+    """Parse OSC 11 response to extract RGB values.
+
+    Expected format: \033]11;rgb:RRRR/GGGG/BBBB\033\\
+    or variants with different terminators.
+    """
+    try:
+        # Look for rgb: pattern
+        if 'rgb:' not in response:
+            return None
+
+        # Extract the RGB part
+        rgb_part = response.split('rgb:')[1]
+        # Remove any escape sequences or terminators
+        rgb_part = rgb_part.split('\033')[0].split('\007')[0]
+
+        # Parse RGB values (format is typically RRRR/GGGG/BBBB in hex)
+        parts = rgb_part.split('/')
+        if len(parts) != 3:
+            return None
+
+        # Convert from hex to 0-255 range
+        # Values are typically 16-bit (0000-FFFF), we need 8-bit (00-FF)
+        r = int(parts[0][:2], 16) if len(parts[0]) >= 2 else int(parts[0], 16)
+        g = int(parts[1][:2], 16) if len(parts[1]) >= 2 else int(parts[1], 16)
+        b = int(parts[2][:2], 16) if len(parts[2]) >= 2 else int(parts[2], 16)
+
+        return (r, g, b)
+    except (ValueError, IndexError):
+        return None
+
+
+def _detect_via_osc11() -> BackgroundMode:
+    """Detect background using OSC 11 escape sequence.
+
+    This queries the terminal for its background color.
+    Returns UNKNOWN if detection fails.
+    """
+    # Only works if stdout is a terminal
+    if not sys.stdout.isatty() or not sys.stdin.isatty():
+        return BackgroundMode.UNKNOWN
+
+    try:
+        # Save current terminal settings
+        old_settings = termios.tcgetattr(sys.stdin.fileno())
+
+        try:
+            # Set terminal to raw mode to read response
+            tty.setraw(sys.stdin.fileno())
+
+            # Send OSC 11 query
+            sys.stdout.write('\033]11;?\033\\')
+            sys.stdout.flush()
+
+            # Wait for response with timeout (100ms)
+            response = ""
+            timeout = 0.1
+
+            while True:
+                # Check if data is available
+                ready, _, _ = select.select([sys.stdin], [], [], timeout)
+                if not ready:
+                    break
+
+                char = sys.stdin.read(1)
+                response += char
+
+                # Check for end of response (either \033\\ or \007)
+                if response.endswith('\033\\') or response.endswith('\007'):
+                    break
+
+                # Safety: don't read forever
+                if len(response) > 100:
+                    break
+
+            # Parse the response
+            rgb = _parse_osc11_response(response)
+            if rgb:
+                r, g, b = rgb
+                luminance = _calculate_luminance(r, g, b)
+
+                # Threshold: > 0.5 is light, <= 0.5 is dark
+                return BackgroundMode.LIGHT if luminance > 0.5 else BackgroundMode.DARK
+
+            return BackgroundMode.UNKNOWN
+
+        finally:
+            # Restore terminal settings
+            termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, old_settings)
+
+    except (OSError, termios.error):
+        # Terminal control not available (e.g., in tests, pipes, etc.)
+        return BackgroundMode.UNKNOWN
+
+
+def _detect_via_colorfgbg() -> BackgroundMode:
+    """Detect background using COLORFGBG environment variable.
+
+    Format is typically "foreground;background" with color codes 0-15.
+    Lower numbers (0-7) are dark, higher (8-15) are light for background.
+    """
+    colorfgbg = os.environ.get('COLORFGBG', '')
+    if not colorfgbg:
+        return BackgroundMode.UNKNOWN
+
+    try:
+        # Parse format: "foreground;background"
+        parts = colorfgbg.split(';')
+        if len(parts) < 2:
+            return BackgroundMode.UNKNOWN
+
+        bg_code = int(parts[-1])  # Background is the last part
+
+        # Typically:
+        # 0-7: dark colors (black, red, green, yellow, blue, magenta, cyan, white)
+        # 8-15: bright versions (light background)
+        # 15 is often white, 0 is black
+
+        if bg_code == 0:  # Black
+            return BackgroundMode.DARK
+        elif bg_code == 15 or bg_code == 7:  # White or light gray
+            return BackgroundMode.LIGHT
+        elif bg_code >= 8:  # Bright colors
+            return BackgroundMode.LIGHT
+        else:  # Dark colors
+            return BackgroundMode.DARK
+
+    except (ValueError, IndexError):
+        return BackgroundMode.UNKNOWN
+
+
+def detect_background() -> BackgroundMode:
+    """Detect terminal background mode (light or dark).
+
+    Tries multiple detection methods in order:
+    1. OSC 11 escape sequence query (most accurate)
+    2. COLORFGBG environment variable
+    3. Defaults to DARK (most common modern terminal default)
+
+    Returns:
+        BackgroundMode enum indicating LIGHT, DARK, or UNKNOWN
+    """
+    # Try OSC 11 first (most accurate)
+    mode = _detect_via_osc11()
+    if mode != BackgroundMode.UNKNOWN:
+        return mode
+
+    # Try COLORFGBG
+    mode = _detect_via_colorfgbg()
+    if mode != BackgroundMode.UNKNOWN:
+        return mode
+
+    # Default to dark (most common nowadays)
+    return BackgroundMode.DARK
+
+
+class DiffColors:
+    """Color scheme for diff display."""
+
+    def __init__(
+        self,
+        left_bg: str,
+        right_bg: str,
+        left_fg: str,
+        right_fg: str,
+    ):
+        """Initialize diff color scheme.
+
+        Args:
+            left_bg: Background color for left side (deletions/changes)
+            right_bg: Background color for right side (additions/changes)
+            left_fg: Foreground color for character-level diffs on left
+            right_fg: Foreground color for character-level diffs on right
+        """
+        self.left_bg = left_bg
+        self.right_bg = right_bg
+        self.left_fg = left_fg
+        self.right_fg = right_fg
+
+
+# Color schemes for different background modes
+LIGHT_MODE_COLORS = DiffColors(
+    left_bg="on rgb(255,235,235)",    # Soft pink background
+    right_bg="on rgb(235,255,235)",   # Soft mint background
+    left_fg="bold rgb(220,0,0)",      # Bright red text
+    right_fg="bold rgb(0,180,0)",     # Bright green text
+)
+
+DARK_MODE_COLORS = DiffColors(
+    left_bg="on rgb(60,20,20)",       # Dark red background
+    right_bg="on rgb(20,60,20)",      # Dark green background
+    left_fg="bold rgb(255,120,120)",  # Light red text
+    right_fg="bold rgb(120,255,120)", # Light green text
+)
+
+
+def get_diff_colors() -> DiffColors:
+    """Get appropriate diff colors based on terminal background.
+
+    Returns:
+        DiffColors instance with colors appropriate for current terminal
+    """
+    mode = detect_background()
+
+    if mode == BackgroundMode.LIGHT:
+        return LIGHT_MODE_COLORS
+    else:
+        # Use dark mode colors for DARK or UNKNOWN
+        return DARK_MODE_COLORS


### PR DESCRIPTION
Implements automatic detection of terminal background (light/dark) and adjusts diff colors accordingly to prevent garish appearance.

Changes:
- Add terminal_detect.py with multiple detection methods:
  * OSC 11 escape sequence query (most accurate)
  * COLORFGBG environment variable fallback
  * Defaults to dark mode (most common)
- Define color schemes for both light and dark backgrounds:
  * Light mode: soft pink/mint backgrounds (existing colors)
  * Dark mode: dark red/green backgrounds with lighter text
- Update diff.py to use adaptive colors instead of hardcoded values
- Calculate luminance to determine light vs dark backgrounds

The implementation works across different terminal emulators and gracefully falls back when detection is unavailable.