### PR TITLE
Debug make bench command issues

### DIFF
--- a/benchmark-tests/run_tests.py
+++ b/benchmark-tests/run_tests.py
@@ -455,8 +455,8 @@ class DuplicationTester:
 def main():
     """Main entry point."""
     parser = argparse.ArgumentParser(description='Run duplication detection tests')
-    parser.add_argument('--ruleset', choices=['none', 'default'], default='default',
-                       help='Ruleset profile to use for tssim (default: default)')
+    parser.add_argument('--ruleset', choices=['none', 'default'], default='none',
+                       help='Ruleset profile to use for tssim (default: none)')
     args = parser.parse_args()
 
     base_dir = Path(__file__).parent

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -93,7 +93,7 @@ class_with_methods_file = fixture_dir / "class_with_methods.py"
             "none",
             fixture_dir,
             0.7,
-            7,
+            6,  # Updated: verification filters out 1 group below order-sensitive threshold
             [
                 # Cross-file duplicate functions
                 (
@@ -132,7 +132,7 @@ class_with_methods_file = fixture_dir / "class_with_methods.py"
             "none",
             fixture_dir,
             0.8,
-            5,
+            4,  # Updated: verification filters out 1 group below order-sensitive threshold
             [
                 # Cross-file duplicate functions
                 (
@@ -176,7 +176,7 @@ class_with_methods_file = fixture_dir / "class_with_methods.py"
             "none",
             fixture_dir,
             0.9,
-            3,  # Updated: also finds test_template_filter functions
+            2,  # Updated: verification filters out 1 group below order-sensitive threshold
             [
                 # Cross-file duplicate functions
                 (

--- a/tssim/pipeline/lsh_stage.py
+++ b/tssim/pipeline/lsh_stage.py
@@ -10,11 +10,9 @@ from tssim.models.shingle import ShingledRegion
 from tssim.models.similarity import (
     Region,
     RegionSignature,
-    SimilarRegionPair,
     SimilarRegionGroup,
     SimilarityResult,
 )
-from tssim.pipeline.verification import verify_similar_pairs
 
 logger = logging.getLogger(__name__)
 
@@ -58,195 +56,11 @@ def _find_signature_by_key(
     )
 
 
-def _create_similar_pair(
-    sig1: RegionSignature,
-    sig2: RegionSignature,
-) -> SimilarRegionPair:
-    """Create a similar region pair with computed similarity. """
-    # If both regions have no shingles, they should not be considered similar
-    # (even though mathematically Jaccard(∅, ∅) = 1.0)
-    if sig1.shingle_count == 0 and sig2.shingle_count == 0:
-        similarity = 0.0
-    else:
-        similarity = sig1.minhash.jaccard(sig2.minhash)
-
-    return SimilarRegionPair(
-        region1=sig1.region,
-        region2=sig2.region,
-        similarity=similarity,
-    )
-
-
-def _is_valid_pair_candidate(
-    sig: RegionSignature,
-    similar_sig: RegionSignature,
-    current_key: str,
-    similar_key: str,
-    seen_pairs: set[tuple[str, str]],
-) -> bool:
-    """Check if a pair is a valid candidate for similarity comparison. """
-    # Skip self-overlapping pairs
-    if _regions_overlap(sig.region, similar_sig.region):
-        return False
-
-    # Check if already processed
-    sorted_keys = sorted([current_key, similar_key])
-    pair_key = (sorted_keys[0], sorted_keys[1])
-    return pair_key not in seen_pairs
-
-
-def _process_candidate_pair(
-    sig: RegionSignature,
-    similar_key: str,
-    current_key: str,
-    signatures: list[RegionSignature],
-    seen_pairs: set[tuple[str, str]],
-    threshold: float,
-) -> SimilarRegionPair | None:
-    """Process a candidate similar pair. """
-    if similar_key == current_key:
-        return None
-
-    similar_sig = _find_signature_by_key(signatures, similar_key)
-    if similar_sig is None:
-        return None
-
-    if not _is_valid_pair_candidate(sig, similar_sig, current_key, similar_key, seen_pairs):
-        return None
-
-    sorted_keys = sorted([current_key, similar_key])
-    pair_key = (sorted_keys[0], sorted_keys[1])
-    seen_pairs.add(pair_key)
-
-    pair = _create_similar_pair(sig, similar_sig)
-    if pair.similarity < threshold:
-        return None
-
-    logger.debug(
-        "Found similar pair: %s ↔ %s (%.1f%% similar)",
-        sig.region.region_name,
-        similar_sig.region.region_name,
-        pair.similarity * 100,
-    )
-
-    return pair
-
-
-def _process_signature_candidates(
-    sig: RegionSignature,
-    lsh: MinHashLSH,
-    signatures: list[RegionSignature],
-    seen_pairs: set[tuple[str, str]],
-    threshold: float,
-) -> list[SimilarRegionPair]:
-    """Process all candidate pairs for a signature. """
-    pairs: list[SimilarRegionPair] = []
-    similar_keys = lsh.query(sig.minhash)
-    current_key = f"{sig.region.path}:{sig.region.start_line}-{sig.region.end_line}"
-
-    for similar_key in similar_keys:
-        pair = _process_candidate_pair(
-            sig, similar_key, current_key, signatures, seen_pairs, threshold
-        )
-        if pair is not None:
-            pairs.append(pair)
-
-    return pairs
-
-
 def _regions_overlap(r1: Region, r2: Region) -> bool:
     """Check if two regions overlap in the same file."""
     if r1.path != r2.path:
         return False
     return not (r1.end_line < r2.start_line or r2.end_line < r1.start_line)
-
-
-def _region_size(region: Region) -> int:
-    """Get the size of a region in lines."""
-    return region.end_line - region.start_line + 1
-
-
-def _pairs_have_overlap(pair1: SimilarRegionPair, pair2: SimilarRegionPair) -> bool:
-    """Check if two pairs have any overlapping regions."""
-    return any(
-        [
-            _regions_overlap(pair1.region1, pair2.region1),
-            _regions_overlap(pair1.region1, pair2.region2),
-            _regions_overlap(pair1.region2, pair2.region1),
-            _regions_overlap(pair1.region2, pair2.region2),
-        ]
-    )
-
-
-def _pair_overlaps_with_any(
-    candidate: SimilarRegionPair, kept_pairs: list[SimilarRegionPair]
-) -> bool:
-    """Check if a candidate pair overlaps with any kept pairs."""
-    return any(_pairs_have_overlap(candidate, kept) for kept in kept_pairs)
-
-
-def _filter_overlapping_pairs(pairs: list[SimilarRegionPair]) -> list[SimilarRegionPair]:
-    """Filter out overlapping pairs using greedy matching to keep the largest regions."""
-    if not pairs:
-        return []
-
-    # Sort by size (largest first) for greedy selection
-    sorted_pairs = sorted(
-        pairs, key=lambda p: (_region_size(p.region1) + _region_size(p.region2)), reverse=True
-    )
-
-    kept_pairs: list[SimilarRegionPair] = []
-
-    for candidate in sorted_pairs:
-        if _pair_overlaps_with_any(candidate, kept_pairs):
-            logger.debug(
-                "Filtering out pair %s:%d-%d ↔ %s:%d-%d (overlaps with kept pair)",
-                candidate.region1.region_name,
-                candidate.region1.start_line,
-                candidate.region1.end_line,
-                candidate.region2.region_name,
-                candidate.region2.start_line,
-                candidate.region2.end_line,
-            )
-            continue
-
-        kept_pairs.append(candidate)
-        logger.debug(
-            "Keeping pair %s:%d-%d ↔ %s:%d-%d (size: %d lines)",
-            candidate.region1.region_name,
-            candidate.region1.start_line,
-            candidate.region1.end_line,
-            candidate.region2.region_name,
-            candidate.region2.start_line,
-            candidate.region2.end_line,
-            _region_size(candidate.region1) + _region_size(candidate.region2),
-        )
-
-    return kept_pairs
-
-
-def _collect_candidate_pairs(
-    signatures: list[RegionSignature],
-    lsh: MinHashLSH,
-    threshold: float,
-) -> list[SimilarRegionPair]:
-    """Collect all candidate pairs from LSH queries."""
-    seen_pairs: set[tuple[str, str]] = set()
-    pairs: list[SimilarRegionPair] = []
-
-    for sig in signatures:
-        sig_pairs = _process_signature_candidates(sig, lsh, signatures, seen_pairs, threshold)
-        if sig_pairs:
-            logger.debug(
-                "Query for %s:%d-%d returned %d candidate pair(s)",
-                sig.region.region_name,
-                sig.region.start_line,
-                sig.region.end_line,
-                len(sig_pairs),
-            )
-        pairs.extend(sig_pairs)
-
-    return pairs
 
 
 class UnionFind:
@@ -480,70 +294,6 @@ def find_similar_groups(
     return groups
 
 
-def find_similar_pairs(
-    signatures: list[RegionSignature],
-    threshold: float = 0.5,
-) -> list[SimilarRegionPair]:
-    """Find similar region pairs using LSH."""
-    if len(signatures) < 2:
-        logger.info("Need at least 2 regions to find similar pairs")
-        return []
-
-    logger.info(
-        "Finding similar pairs using LSH (threshold=%.2f) for %d region(s)",
-        threshold,
-        len(signatures),
-    )
-
-    lsh = _create_lsh_index(signatures, threshold)
-    pairs = _collect_candidate_pairs(signatures, lsh, threshold)
-
-    pairs.sort(key=lambda p: p.similarity, reverse=True)
-    logger.info(
-        "Found %d similar pair(s) above threshold (%d self-similar)",
-        len(pairs),
-        sum(1 for p in pairs if p.is_self_similarity),
-    )
-
-    # Apply greedy filtering to remove overlapping matches
-    filtered_pairs = _filter_overlapping_pairs(pairs)
-    if len(filtered_pairs) < len(pairs):
-        logger.info(
-            "Filtered %d overlapping pair(s), keeping %d largest region(s)",
-            len(pairs) - len(filtered_pairs),
-            len(filtered_pairs),
-        )
-
-    return filtered_pairs
-
-
-def _should_verify_candidates(
-    verify_candidates: bool,
-    shingled_regions: list[ShingledRegion] | None,
-    candidate_pairs: list[SimilarRegionPair],
-) -> bool:
-    """Check if candidate verification should be performed."""
-    return verify_candidates and shingled_regions is not None and len(candidate_pairs) > 0
-
-
-def _verify_and_filter_pairs(
-    candidate_pairs: list[SimilarRegionPair],
-    shingled_regions: list[ShingledRegion],
-    threshold: float,
-) -> list[SimilarRegionPair]:
-    """Verify candidate pairs and filter by threshold."""
-    logger.info("Verifying %d candidate pair(s)", len(candidate_pairs))
-    verified_pairs = verify_similar_pairs(candidate_pairs, shingled_regions)
-
-    similar_pairs = [p for p in verified_pairs if p.similarity >= threshold]
-    if len(similar_pairs) < len(verified_pairs):
-        logger.info(
-            "Filtered %d pair(s) below threshold after verification",
-            len(verified_pairs) - len(similar_pairs),
-        )
-    return similar_pairs
-
-
 def detect_similarity(
     signatures: list[RegionSignature],
     threshold: float = 0.5,
@@ -553,7 +303,24 @@ def detect_similarity(
 ) -> SimilarityResult:
     """Detect similar regions using LSH."""
     # Find groups of similar regions
-    similar_groups = find_similar_groups(signatures, threshold=threshold)
+    candidate_groups = find_similar_groups(signatures, threshold=threshold)
+
+    # Verify groups using order-sensitive similarity if requested
+    if verify_candidates and shingled_regions is not None and len(candidate_groups) > 0:
+        from tssim.pipeline.verification import verify_similar_groups
+
+        logger.info("Verifying %d candidate group(s)", len(candidate_groups))
+        verified_groups = verify_similar_groups(candidate_groups, shingled_regions)
+
+        # Filter groups that fall below threshold after verification
+        similar_groups = [g for g in verified_groups if g.similarity >= threshold]
+        if len(similar_groups) < len(verified_groups):
+            logger.info(
+                "Filtered %d group(s) below threshold after verification",
+                len(verified_groups) - len(similar_groups),
+            )
+    else:
+        similar_groups = candidate_groups
 
     return SimilarityResult(
         signatures=signatures,


### PR DESCRIPTION
This commit addresses two issues:

1. Changed benchmark default ruleset from 'default' to 'none'
   - Updated benchmark-tests/run_tests.py to use 'none' as default
   - This ensures benchmarks run without normalization rules by default

2. Added order-sensitive verification using LCS for group matching
   - Implemented verify_similar_groups() in verification.py
   - Uses Longest Common Subsequence (LCS) to verify that matches respect line order, not just set similarity
   - Updated detect_similarity() to call verification for groups
   - Fixes issue where minhash-LSF (order-insensitive) was reporting 100% matches for regions with different line orders

3. Removed dead code
   - Removed unused pairs-based matching functions
   - Removed verify_similar_pairs and related helpers
   - Pipeline now exclusively uses groups-based matching
   - Updated tests to reflect new expected counts after verification

The LCS verification ensures that 100% matches are truly identical in both content and order, preventing false positives from the order-insensitive minhash-LSF algorithm.