### PR TITLE
Fix missing file count in stats display

### DIFF
--- a/tssim/cli.py
+++ b/tssim/cli.py
@@ -129,27 +129,39 @@ def display_failed_files(result: SimilarityResult, show_details: bool) -> None:
             console.print(f"    [dim]{error}[/dim]")
 
 
-def _collect_format_statistics(result: SimilarityResult) -> dict[str, dict[str, int | set[Path]]]:
-    """Collect statistics by language/format from all processed files."""
+def _init_language_stats(
+    stats_by_format: dict[str, dict[str, int | set[Path]]], language: str
+) -> None:
+    """Initialize stats entry for a language if not present."""
+    if language not in stats_by_format:
+        stats_by_format[language] = {"files": set(), "groups": 0, "lines": 0}
+
+
+def _collect_files_from_signatures(
+    signatures: list[RegionSignature],
+) -> dict[str, dict[str, int | set[Path]]]:
+    """Collect all processed files from signatures."""
     stats_by_format: dict[str, dict[str, int | set[Path]]] = {}
 
-    # First, collect all processed files from signatures
-    for signature in result.signatures:
+    for signature in signatures:
         region = signature.region
         language = region.language
-        if language not in stats_by_format:
-            stats_by_format[language] = {"files": set(), "groups": 0, "lines": 0}
-
+        _init_language_stats(stats_by_format, language)
         stats = stats_by_format[language]
         stats["files"].add(region.path)  # type: ignore[union-attr]
 
-    # Then, add group counts and duplicate lines from similar groups
-    for group in result.similar_groups:
+    return stats_by_format
+
+
+def _add_duplicate_stats(
+    stats_by_format: dict[str, dict[str, int | set[Path]]],
+    similar_groups: list[SimilarRegionGroup],
+) -> None:
+    """Add group counts and duplicate lines from similar groups."""
+    for group in similar_groups:
         for region in group.regions:
             language = region.language
-            if language not in stats_by_format:
-                stats_by_format[language] = {"files": set(), "groups": 0, "lines": 0}
-
+            _init_language_stats(stats_by_format, language)
             stats = stats_by_format[language]
             stats["lines"] += region.end_line - region.start_line + 1  # type: ignore[operator]
 
@@ -158,6 +170,11 @@ def _collect_format_statistics(result: SimilarityResult) -> dict[str, dict[str, 
             first_language = group.regions[0].language
             stats_by_format[first_language]["groups"] += 1  # type: ignore[operator]
 
+
+def _collect_format_statistics(result: SimilarityResult) -> dict[str, dict[str, int | set[Path]]]:
+    """Collect statistics by language/format from all processed files."""
+    stats_by_format = _collect_files_from_signatures(result.signatures)
+    _add_duplicate_stats(stats_by_format, result.similar_groups)
     return stats_by_format
 
 

--- a/tssim/cli.py
+++ b/tssim/cli.py
@@ -129,18 +129,28 @@ def display_failed_files(result: SimilarityResult, show_details: bool) -> None:
             console.print(f"    [dim]{error}[/dim]")
 
 
-def _collect_format_statistics(similar_groups: list[SimilarRegionGroup]) -> dict[str, dict[str, int | set[Path]]]:
-    """Collect statistics by language/format from similar groups."""
+def _collect_format_statistics(result: SimilarityResult) -> dict[str, dict[str, int | set[Path]]]:
+    """Collect statistics by language/format from all processed files."""
     stats_by_format: dict[str, dict[str, int | set[Path]]] = {}
 
-    for group in similar_groups:
+    # First, collect all processed files from signatures
+    for signature in result.signatures:
+        region = signature.region
+        language = region.language
+        if language not in stats_by_format:
+            stats_by_format[language] = {"files": set(), "groups": 0, "lines": 0}
+
+        stats = stats_by_format[language]
+        stats["files"].add(region.path)  # type: ignore[union-attr]
+
+    # Then, add group counts and duplicate lines from similar groups
+    for group in result.similar_groups:
         for region in group.regions:
             language = region.language
             if language not in stats_by_format:
                 stats_by_format[language] = {"files": set(), "groups": 0, "lines": 0}
 
             stats = stats_by_format[language]
-            stats["files"].add(region.path)  # type: ignore[union-attr]
             stats["lines"] += region.end_line - region.start_line + 1  # type: ignore[operator]
 
         # Count group once per language (use first region's language)
@@ -153,10 +163,11 @@ def _collect_format_statistics(similar_groups: list[SimilarRegionGroup]) -> dict
 
 def display_summary_table(result: SimilarityResult) -> None:
     """Display summary table with statistics by format."""
-    if not result.similar_groups:
+    # Show stats even if no similar groups found (to show all processed files)
+    if not result.signatures:
         return
 
-    stats_by_format = _collect_format_statistics(result.similar_groups)
+    stats_by_format = _collect_format_statistics(result)
 
     # Create summary table
     table = Table(title="\n[bold cyan]Summary[/bold cyan]", show_header=True, header_style="bold")


### PR DESCRIPTION
…ates

Previously, the summary table only showed file types that had duplicate groups, which meant file types without any duplicates (like markdown, bash, etc.) were not displayed in the stats.

Changed _collect_format_statistics to:
- First collect all processed files from result.signatures (all files)
- Then add group counts and duplicate lines from similar_groups
- Updated display_summary_table to show stats even when no duplicates found

This ensures users see the complete picture of what files were processed, regardless of whether duplicates were found.