### PR TITLE
Fix treesitter subcommand path handling

### DIFF
--- a/tssim/cli.py
+++ b/tssim/cli.py
@@ -311,9 +311,8 @@ def _check_result_errors(result: SimilarityResult, output_format: str) -> None:
         sys.exit(1)
 
 
-@click.group(invoke_without_command=True)
+@click.group()
 @click.pass_context
-@click.argument("path", type=click.Path(exists=True, path_type=Path), required=False)
 @click.option(
     "--log-level",
     type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], case_sensitive=False),
@@ -334,7 +333,6 @@ def _check_result_errors(result: SimilarityResult, output_format: str) -> None:
 )
 def main(
     ctx: click.Context,
-    path: Path | None,
     log_level: str,
     ruleset: str,
     list_ruleset: str | None,
@@ -346,16 +344,11 @@ def main(
     ctx.ensure_object(dict)
     ctx.obj["log_level"] = log_level
     ctx.obj["ruleset"] = ruleset
-    ctx.obj["path"] = path
 
     # Handle --list-ruleset option
     if list_ruleset is not None:
         _print_rulesets(list_ruleset)
         sys.exit(0)
-
-    # If no subcommand specified but path provided, invoke detect by default
-    if ctx.invoked_subcommand is None and path is not None:
-        ctx.invoke(detect, path=path)
 
 
 @main.command()
@@ -476,7 +469,7 @@ def _display_region_shingles(
 
     # Reset identifiers for consistent output
     shingler.rule_engine.reset_identifiers()
-    shingler.rule_engine.precompute_queries(extracted_region.node, region_info.language)
+    shingler.rule_engine.precompute_queries(extracted_region.node, region_info.language, source)
 
     # Extract shingles
     shingled_region = shingler.shingle_region(extracted_region, source)

--- a/tssim/pipeline/rules/engine.py
+++ b/tssim/pipeline/rules/engine.py
@@ -32,7 +32,7 @@ class RuleEngine:
     ) -> dict[
         RuleAction,
         Callable[
-            [Rule, str, str, Optional[str], Optional[str]],
+            [Rule, Node, str, str, Optional[str], Optional[str]],
             tuple[Optional[str], Optional[str]],
         ],
     ]:
@@ -130,7 +130,7 @@ class RuleEngine:
         return None
 
     def _handle_remove(
-        self, rule: Rule, node_type: str, language: str, name: Optional[str], value: Optional[str]
+        self, rule: Rule, node: Node, node_type: str, language: str, name: Optional[str], value: Optional[str]
     ) -> tuple[Optional[str], Optional[str]]:
         """Handle REMOVE action - skip/remove matched nodes."""
         raise SkipNodeException(
@@ -138,13 +138,13 @@ class RuleEngine:
         )
 
     def _handle_rename(
-        self, rule: Rule, node_type: str, language: str, name: Optional[str], value: Optional[str]
+        self, rule: Rule, node: Node, node_type: str, language: str, name: Optional[str], value: Optional[str]
     ) -> tuple[Optional[str], Optional[str]]:
         """Handle RENAME action - rename matched nodes."""
         return rule.params.get("token", "<NODE>"), value
 
     def _handle_replace_value(
-        self, rule: Rule, node_type: str, language: str, name: Optional[str], value: Optional[str]
+        self, rule: Rule, node: Node, node_type: str, language: str, name: Optional[str], value: Optional[str]
     ) -> tuple[Optional[str], Optional[str]]:
         """Handle REPLACE_VALUE action - replace node values."""
         return name, rule.params.get("value", "<LIT>")
@@ -162,13 +162,13 @@ class RuleEngine:
         return name, self._get_anonymized_identifier(prefix, original_value)
 
     def _handle_canonicalize(
-        self, rule: Rule, node_type: str, language: str, name: Optional[str], value: Optional[str]
+        self, rule: Rule, node: Node, node_type: str, language: str, name: Optional[str], value: Optional[str]
     ) -> tuple[Optional[str], Optional[str]]:
         """Handle CANONICALIZE action - canonicalize types."""
         return rule.params.get("token", "<TYPE>"), value
 
     def _handle_extract_region(
-        self, rule: Rule, node_type: str, language: str, name: Optional[str], value: Optional[str]
+        self, rule: Rule, node: Node, node_type: str, language: str, name: Optional[str], value: Optional[str]
     ) -> tuple[Optional[str], Optional[str]]:
         """Handle EXTRACT_REGION action - mark regions for extraction (no-op for normalization)."""
         return name, value
@@ -182,11 +182,7 @@ class RuleEngine:
 
         handler = self._action_handlers.get(rule.action)
         if handler:
-            # ANONYMIZE handler needs the node to extract original text
-            if rule.action == RuleAction.ANONYMIZE:
-                return handler(rule, node, node_type, language, name, value)
-            else:
-                return handler(rule, node_type, language, name, value)
+            return handler(rule, node, node_type, language, name, value)
 
         return name, value
 

--- a/tssim/pipeline/shingle.py
+++ b/tssim/pipeline/shingle.py
@@ -227,7 +227,7 @@ def _shingle_single_region(
     # Pre-execute all queries for this region to populate the cache upfront
     # This is a performance optimization to avoid lazy query execution during traversal
     shingler.rule_engine.precompute_queries(
-        extracted_region.node, extracted_region.region.language
+        extracted_region.node, extracted_region.region.language, source
     )
 
     return shingler.shingle_region(extracted_region, source)


### PR DESCRIPTION
This commit addresses two critical issues:

1. CLI path handling: Removed the PATH argument from the main command group to allow subcommands to be called directly. Previously, the treesitter subcommand couldn't accept file paths because Click was interpreting the subcommand name as the PATH argument.

2. Variable normalization: Fixed identifier anonymization to maintain consistency within scope. The anonymization now tracks a mapping from original identifier text to anonymized names, ensuring the same variable gets the same anonymized name throughout its scope.

   Changes:
   - Added _identifier_mapping dict to RuleEngine to track original identifier text to anonymized name mappings
   - Modified _get_anonymized_identifier to use original value as key
   - Updated _handle_anonymize to extract node text from source bytes
   - Added source parameter to precompute_queries method
   - Updated all call sites to pass source bytes

Before this fix, variables would get different anonymized names each time they appeared (e.g., value -> VAR_3 then VAR_4). After the fix, the same variable consistently gets the same anonymized name (e.g., value -> VAR_3 in all occurrences).