### PR TITLE
Add file type detection with python-magic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "datasketch>=1.6.5",
     "pydantic>=2.12.3",
     "pydantic-settings>=2.0.0",
+    "python-magic>=0.4.27",
     "rich>=14.2.0",
     "sarif-pydantic>=0.6.2",
     "tdqm>=0.0.1",

--- a/tssim/pipeline/magic_detector.py
+++ b/tssim/pipeline/magic_detector.py
@@ -1,0 +1,178 @@
+"""File type detection using python-magic with fallback to extension-based detection."""
+
+import logging
+from pathlib import Path
+from typing import Literal
+
+import magic
+
+logger = logging.getLogger(__name__)
+
+# Type alias for supported languages (must match LANGUAGE_CONFIGS)
+LanguageName = Literal[
+    "python",
+    "javascript",
+    "typescript",
+    "tsx",
+    "jsx",
+    "html",
+    "css",
+    "java",
+    "sql",
+    "bash",
+    "rust",
+    "ruby",
+    "go",
+    "csharp",
+    "markdown",
+]
+
+# Mapping of MIME types to language names
+# Only includes languages that exist in LANGUAGE_CONFIGS
+MIME_TO_LANGUAGE: dict[str, LanguageName] = {
+    # Python
+    "text/x-python": "python",
+    "text/x-script.python": "python",
+    # JavaScript
+    "text/javascript": "javascript",
+    "application/javascript": "javascript",
+    "application/x-javascript": "javascript",
+    # TypeScript (note: magic might not detect these well, will rely on extension fallback)
+    "text/x-typescript": "typescript",
+    # HTML
+    "text/html": "html",
+    # CSS
+    "text/css": "css",
+    # Java
+    "text/x-java": "java",
+    "text/x-java-source": "java",
+    # SQL
+    "text/x-sql": "sql",
+    "application/sql": "sql",
+    # Bash/Shell
+    "text/x-shellscript": "bash",
+    "application/x-sh": "bash",
+    "application/x-shellscript": "bash",
+    # Rust
+    "text/x-rust": "rust",
+    # Ruby
+    "text/x-ruby": "ruby",
+    "text/x-script.ruby": "ruby",
+    "application/x-ruby": "ruby",
+    # Go
+    "text/x-go": "go",
+    # C#
+    "text/x-csharp": "csharp",
+    # Markdown
+    "text/markdown": "markdown",
+    "text/x-markdown": "markdown",
+}
+
+# File extension mapping as fallback
+# Only includes extensions for languages that exist in LANGUAGE_CONFIGS
+EXTENSION_TO_LANGUAGE: dict[str, LanguageName] = {
+    ".py": "python",
+    ".pyw": "python",
+    ".js": "javascript",
+    ".jsx": "jsx",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".html": "html",
+    ".htm": "html",
+    ".css": "css",
+    ".java": "java",
+    ".sql": "sql",
+    ".sh": "bash",
+    ".bash": "bash",
+    ".rs": "rust",
+    ".rb": "ruby",
+    ".go": "go",
+    ".cs": "csharp",
+    ".md": "markdown",
+    ".markdown": "markdown",
+}
+
+
+def _detect_by_magic(file_path: Path) -> LanguageName | None:
+    """Detect file type using python-magic."""
+    try:
+        mime = magic.from_file(str(file_path), mime=True)
+        logger.debug(f"Detected MIME type for {file_path}: {mime}")
+
+        # Map MIME type to language
+        language = MIME_TO_LANGUAGE.get(mime)
+        if language:
+            logger.debug(f"Mapped MIME type {mime} to language {language}")
+            return language
+
+        return None
+    except Exception as e:
+        logger.debug(f"Magic detection failed for {file_path}: {e}")
+        return None
+
+
+def _detect_by_extension(file_path: Path) -> LanguageName | None:
+    """Detect file type by extension."""
+    suffix = file_path.suffix.lower()
+    language = EXTENSION_TO_LANGUAGE.get(suffix)
+    if language:
+        logger.debug(f"Detected language {language} from extension {suffix}")
+    return language
+
+
+# Set of supported languages (must match LANGUAGE_CONFIGS)
+SUPPORTED_LANGUAGES = {
+    "python",
+    "javascript",
+    "typescript",
+    "tsx",
+    "jsx",
+    "html",
+    "css",
+    "java",
+    "sql",
+    "bash",
+    "rust",
+    "ruby",
+    "go",
+    "csharp",
+    "markdown",
+}
+
+
+def _is_supported_language(language: str | None) -> bool:
+    """Check if a language is supported."""
+    if language is None:
+        return False
+    return language in SUPPORTED_LANGUAGES
+
+
+def detect_language_with_magic(file_path: Path) -> LanguageName | None:
+    """
+    Detect programming language using python-magic with extension fallback.
+
+    Only returns languages that exist in tssim.pipeline.languages.LANGUAGE_CONFIGS.
+
+    Args:
+        file_path: Path to the file to detect
+
+    Returns:
+        Language name if detected and supported, None otherwise
+    """
+    # First try magic detection
+    language = _detect_by_magic(file_path)
+
+    # If magic detection failed or returned unsupported language, try extension
+    if not _is_supported_language(language):
+        logger.debug(f"Magic detection failed or unsupported for {file_path}, trying extension")
+        language = _detect_by_extension(file_path)
+
+    # Validate the detected language is supported
+    if _is_supported_language(language):
+        logger.debug(f"Final detected language for {file_path}: {language}")
+        return language
+
+    logger.debug(f"No supported language detected for {file_path}")
+    return None

--- a/uv.lock
+++ b/uv.lock
@@ -579,6 +579,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-magic"
+version = "0.4.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b", size = 14677, upload-time = "2022-06-07T20:16:59.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3", size = 13840, upload-time = "2022-06-07T20:16:57.763Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -957,6 +966,7 @@ dependencies = [
     { name = "datasketch" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-magic" },
     { name = "rich" },
     { name = "sarif-pydantic" },
     { name = "tdqm" },
@@ -980,6 +990,7 @@ requires-dist = [
     { name = "datasketch", specifier = ">=1.6.5" },
     { name = "pydantic", specifier = ">=2.12.3" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "python-magic", specifier = ">=0.4.27" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "sarif-pydantic", specifier = ">=0.6.2" },
     { name = "tdqm", specifier = ">=0.0.1" },


### PR DESCRIPTION
This commit implements file type detection using python-magic library with fallback to extension-based detection. The implementation only accepts file types that are defined in tssim/pipeline/languages/__init__.py.

Changes:
- Add python-magic>=0.4.27 to dependencies
- Create new tssim/pipeline/magic_detector.py module with:
  - MIME type to language mapping
  - Extension-based fallback detection
  - Validation against LANGUAGE_CONFIGS supported languages
- Update tssim/pipeline/parse.py to use magic-based detection
- Ensure only supported languages (python, javascript, typescript, tsx, jsx, html, css, java, sql, bash, rust, ruby, go, csharp, markdown) are detected

The magic detector uses MIME type detection as the primary method and falls back to extension-based detection when magic detection fails or returns an unsupported language.