### PR TITLE
Make list-ruleset its own subcommand

### DIFF
--- a/whorl/cli.py
+++ b/whorl/cli.py
@@ -258,33 +258,45 @@ def _print_rule_spec(rule: Any) -> None:
     console.print(f"    [dim]query: {query_preview}[/dim]\n")
 
 
+def _build_ruleset_header(ruleset_name: str, language_filter: str | None) -> str:
+    """Build the ruleset header with optional language filter."""
+    header = f"Ruleset: {ruleset_name}"
+    if language_filter:
+        header += f" (language: {language_filter})"
+    return header
+
+
+def _print_empty_ruleset_message(language_filter: str | None) -> None:
+    """Print message when no rules are found."""
+    if language_filter:
+        console.print(f"  [dim]No rules found for language '{language_filter}'[/dim]\n")
+    else:
+        console.print("  [dim]No normalization rules - raw AST comparison[/dim]\n")
+
+
+def _filter_rules_by_language(
+    rules: list[tuple[Any, str]], language_filter: str | None
+) -> list[tuple[Any, str]]:
+    """Filter rules by language if specified."""
+    if not language_filter:
+        return rules
+    return [(rule, desc) for rule, desc in rules if language_filter in rule.languages]
+
+
 def _print_rulesets(ruleset_name: str, language_filter: str | None = None) -> None:
     """Print rules in the specified ruleset, optionally filtered by language."""
     from whorl.pipeline.rules_factory import get_ruleset_with_descriptions
 
     rules_with_descriptions = get_ruleset_with_descriptions(ruleset_name)
+    rules_with_descriptions = _filter_rules_by_language(rules_with_descriptions, language_filter)
 
-    # Filter by language if specified
-    if language_filter:
-        rules_with_descriptions = [
-            (rule, desc) for rule, desc in rules_with_descriptions
-            if language_filter in rule.languages
-        ]
-
-    # Display header with ruleset name and optional language filter
-    header = f"Ruleset: {ruleset_name}"
-    if language_filter:
-        header += f" (language: {language_filter})"
+    header = _build_ruleset_header(ruleset_name, language_filter)
     console.print(f"\n[bold blue]{header}[/bold blue]\n")
 
     if not rules_with_descriptions:
-        if language_filter:
-            console.print(f"  [dim]No rules found for language '{language_filter}'[/dim]\n")
-        else:
-            console.print("  [dim]No normalization rules - raw AST comparison[/dim]\n")
+        _print_empty_ruleset_message(language_filter)
         return
 
-    # Display each rule with its description
     console.print(f"[dim]{len(rules_with_descriptions)} rule(s):[/dim]\n")
     for rule, description in rules_with_descriptions:
         console.print(f"  [cyan]•[/cyan] {description}")


### PR DESCRIPTION
- Remove --list-ruleset flag from main group command
- Create new list-ruleset subcommand
- Add --language/-l option to filter rules by programming language
- Update _print_rulesets to support optional language filtering
- Improve user experience by providing clearer feedback when no rules are found