### PR TITLE
Investigate single region file handling

### DIFF
--- a/SINGLE_REGION_ISSUE.md
+++ b/SINGLE_REGION_ISSUE.md
@@ -1,0 +1,184 @@
+# Single Region Line-Level Matching Issue
+
+## Summary
+
+Files treated as "one region" (CSS, bash, SQL) cannot detect identical blocks of code when the files as a whole are not similar enough to match in Level 1.
+
+## The Problem
+
+### Current Behavior
+
+When a file language doesn't have region extraction rules (CSS, bash, SQL):
+
+1. **Level 1**: The entire file is treated as ONE region (`region_type="file"`)
+2. **If no Level 1 match**: The entire file is marked as unmatched
+3. **Level 2**: Creates ONE line-based region for the entire unmatched file
+4. **Result**: Small identical blocks within otherwise different files are NOT detected
+
+### Why This Happens
+
+The line-level matching (Level 2) only creates line-based regions from **unmatched gaps** between Level 1 matches. For single-region files:
+
+- If the whole file doesn't match in Level 1 → the whole file is one big gap
+- Level 2 creates one line-based region for the entire file
+- This is essentially the same comparison as Level 1
+- No chunking or sliding window occurs
+
+### Code Location
+
+**Region extraction** (`whorl/pipeline/region_extraction.py:109-123`):
+```python
+if not mappings:
+    # For unsupported languages, treat the entire file as one region
+    logger.warning(
+        "Language '%s' not supported for region extraction, treating entire file as one region",
+        parsed_file.language,
+    )
+    region = Region(
+        path=parsed_file.path,
+        language=parsed_file.language,
+        region_type="file",
+        region_name=parsed_file.path.name,
+        start_line=1,
+        end_line=parsed_file.root_node.end_point[0] + 1,
+    )
+    regions = [ExtractedRegion(region=region, node=parsed_file.root_node)]
+```
+
+**Line-based region creation** (`whorl/pipeline/region_extraction.py:213-242`):
+```python
+def create_line_based_regions(
+    parsed_files: list[ParsedFile],
+    matched_lines_by_file: dict[Path, set[int]],
+    min_lines: int,
+) -> list[ExtractedRegion]:
+    """Create line-based regions for unmatched sections of files."""
+    line_regions: list[ExtractedRegion] = []
+
+    for parsed_file in parsed_files:
+        matched_lines = matched_lines_by_file.get(parsed_file.path, set())
+        file_end_line = parsed_file.root_node.end_point[0] + 1
+
+        unmatched_ranges = _find_unmatched_ranges(matched_lines, file_end_line)
+
+        for start_line, end_line in unmatched_ranges:
+            line_count = end_line - start_line + 1
+            if line_count >= min_lines:
+                extracted_region = _create_line_region(parsed_file, start_line, end_line)
+                line_regions.append(extracted_region)
+```
+
+**Key issue**: `_find_unmatched_ranges()` finds gaps between matched lines. If there are no matched lines, it returns ONE range for the entire file.
+
+## Test Case Demonstration
+
+**Test**: `tests/pipeline/test_pipeline.py::test_single_region_files_with_identical_blocks`
+
+**Setup**:
+- Two CSS files with completely different content
+- Both share an identical 22-line block in the middle
+- File 1: 132 lines total (~17% overlap)
+- File 2: 153 lines total (~14% overlap)
+
+**Expected**: The identical block should be detected by line-level matching
+
+**Actual Result**:
+```
+Total similar groups found: 1
+
+Group 1:
+  Similarity: 44.28%
+  Regions:
+    - comprehensive.css:1-210 (file) [comprehensive.css]
+    - file_with_shared_block_1.css:1-132 (file) [file_with_shared_block_1.css]
+
+Groups containing both test files: 0
+
+ISSUE: No shared identical block was detected!
+```
+
+## Impact
+
+This affects:
+1. **CSS files**: Can't detect shared utility classes or component styles
+2. **Bash scripts**: Can't detect identical helper functions
+3. **SQL files**: Can't detect shared stored procedures or query patterns
+4. **Any language without region extraction rules**
+
+## Potential Solutions
+
+### Option 1: Chunk-Based Approach for Single-Region Files
+
+When a file is treated as a single region AND doesn't match in Level 1, break it into overlapping or non-overlapping chunks for Level 2:
+
+```python
+def create_line_based_regions_for_single_region_files(
+    parsed_file: ParsedFile,
+    chunk_size: int = 50,  # Lines per chunk
+    overlap: int = 10,     # Overlap between chunks
+) -> list[ExtractedRegion]:
+    """Create overlapping line-based chunks for single-region files."""
+    # Implementation would create sliding window chunks
+```
+
+**Pros**:
+- Would detect identical blocks within different files
+- Configurable chunk size and overlap
+- Minimal impact on existing code
+
+**Cons**:
+- More regions to compare (performance impact)
+- May create false positives with very small chunks
+- Need to tune chunk_size and overlap parameters
+
+### Option 2: Add Region Extraction Rules for CSS/Bash/SQL
+
+Implement proper region extraction for these languages:
+
+- **CSS**: Extract rule sets, media queries, keyframes
+- **Bash**: Extract functions (already possible with tree-sitter)
+- **SQL**: Extract stored procedures, functions, views
+
+**Pros**:
+- More accurate comparisons
+- Leverages existing Level 1 infrastructure
+- Semantic understanding of code structure
+
+**Cons**:
+- Requires tree-sitter query development for each language
+- More complex implementation
+- Ongoing maintenance
+
+### Option 3: Hybrid Approach
+
+1. Add region extraction for languages where it makes sense (Bash functions, SQL procedures)
+2. Use chunk-based approach for truly flat files (CSS, config files)
+
+## Recommendation
+
+**Short-term**: Add region extraction rules for Bash and SQL, as they have clear function/procedure boundaries
+
+**Long-term**: Implement chunk-based approach for CSS and other truly flat file formats
+
+## Running the Test
+
+```bash
+uv run pytest tests/pipeline/test_pipeline.py::test_single_region_files_with_identical_blocks -v -s --no-cov
+```
+
+The test currently **fails** (as expected), demonstrating the issue.
+
+## Related Files
+
+- Test fixtures:
+  - `tests/fixtures/css/file_with_shared_block_1.css` (132 lines, shared block at lines 47-68)
+  - `tests/fixtures/css/file_with_shared_block_2.css` (153 lines, shared block at lines 55-76)
+- Language implementations:
+  - `whorl/pipeline/languages/css.py:57-58`
+  - `whorl/pipeline/languages/bash.py:57-58`
+  - `whorl/pipeline/languages/sql.py:52-53`
+- Region extraction logic:
+  - `whorl/pipeline/region_extraction.py:109-123` (single region creation)
+  - `whorl/pipeline/region_extraction.py:213-242` (line-based region creation)
+- Pipeline logic:
+  - `whorl/pipeline/pipeline.py:184-219` (Level 2 matching)

--- a/tests/fixtures/css/file_with_shared_block_1.css
+++ b/tests/fixtures/css/file_with_shared_block_1.css
@@ -1,0 +1,131 @@
+/* First CSS file with extensive unique header styles */
+.header-unique-1 {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 40px;
+    font-size: 28px;
+    text-align: center;
+    font-family: 'Helvetica Neue', sans-serif;
+}
+
+.nav-unique-1 {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(10px);
+}
+
+.nav-item-unique-1 {
+    padding: 12px 20px;
+    margin: 0 5px;
+    transition: all 0.3s ease;
+    border-radius: 6px;
+}
+
+.nav-item-unique-1:hover {
+    background: rgba(255, 255, 255, 0.2);
+    transform: translateY(-2px);
+}
+
+.hero-section-unique-1 {
+    min-height: 600px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-image: url('hero-bg.jpg');
+    background-size: cover;
+}
+
+.hero-title-unique-1 {
+    font-size: 48px;
+    font-weight: bold;
+    text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+}
+
+/* SHARED BLOCK START - This block is identical in both files */
+.shared-button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.shared-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.shared-card {
+    background: white;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    border-radius: 8px;
+    padding: 16px;
+}
+/* SHARED BLOCK END */
+
+/* Extensive unique footer styles for file 1 */
+.footer-unique-1 {
+    background: linear-gradient(180deg, #1e3c72 0%, #2a5298 100%);
+    color: #fff;
+    text-align: center;
+    padding: 60px 20px;
+}
+
+.footer-links-unique-1 {
+    display: flex;
+    justify-content: center;
+    gap: 30px;
+    margin-bottom: 30px;
+}
+
+.footer-link-unique-1 {
+    color: #fff;
+    text-decoration: none;
+    font-size: 16px;
+    transition: opacity 0.3s;
+}
+
+.footer-link-unique-1:hover {
+    opacity: 0.8;
+}
+
+.social-icons-unique-1 {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.social-icon-unique-1 {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.copyright-unique-1 {
+    font-size: 14px;
+    margin-top: 30px;
+    opacity: 0.8;
+}
+
+.newsletter-unique-1 {
+    max-width: 500px;
+    margin: 0 auto 30px;
+}
+
+.newsletter-input-unique-1 {
+    padding: 12px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+    border-radius: 4px;
+    width: 100%;
+}

--- a/tests/fixtures/css/file_with_shared_block_2.css
+++ b/tests/fixtures/css/file_with_shared_block_2.css
@@ -1,0 +1,152 @@
+/* Second CSS file with completely different dashboard styles */
+.dashboard-container-unique-2 {
+    display: grid;
+    grid-template-columns: 250px 1fr;
+    grid-template-rows: 60px 1fr;
+    min-height: 100vh;
+    background: #f8f9fa;
+}
+
+.sidebar-unique-2 {
+    grid-row: 1 / -1;
+    background: #2c3e50;
+    color: white;
+    padding: 20px;
+    box-shadow: 2px 0 5px rgba(0,0,0,0.1);
+}
+
+.sidebar-logo-unique-2 {
+    font-size: 24px;
+    font-weight: bold;
+    margin-bottom: 40px;
+    text-align: center;
+}
+
+.menu-item-unique-2 {
+    padding: 12px 16px;
+    margin-bottom: 8px;
+    cursor: pointer;
+    border-radius: 8px;
+    transition: background-color 0.3s;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.menu-item-unique-2:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.menu-item-unique-2.active {
+    background: #3498db;
+}
+
+.topbar-unique-2 {
+    grid-column: 2;
+    background: white;
+    padding: 0 30px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+/* SHARED BLOCK START - This block is identical in both files */
+.shared-button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.shared-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.shared-card {
+    background: white;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    border-radius: 8px;
+    padding: 16px;
+}
+/* SHARED BLOCK END */
+
+/* Completely different data visualization styles */
+.dashboard-content-unique-2 {
+    grid-column: 2;
+    grid-row: 2;
+    padding: 30px;
+}
+
+.stats-grid-unique-2 {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+.stat-card-unique-2 {
+    background: white;
+    padding: 25px;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    border-left: 4px solid #3498db;
+}
+
+.stat-value-unique-2 {
+    font-size: 36px;
+    font-weight: bold;
+    color: #2c3e50;
+    margin-bottom: 8px;
+}
+
+.stat-label-unique-2 {
+    font-size: 14px;
+    color: #7f8c8d;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.chart-container-unique-2 {
+    background: white;
+    padding: 30px;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    margin-bottom: 30px;
+}
+
+.chart-title-unique-2 {
+    font-size: 20px;
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 20px;
+}
+
+.data-table-unique-2 {
+    width: 100%;
+    background: white;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+}
+
+.table-header-unique-2 {
+    background: #ecf0f1;
+    padding: 16px;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.table-row-unique-2 {
+    padding: 16px;
+    border-bottom: 1px solid #ecf0f1;
+    transition: background-color 0.2s;
+}
+
+.table-row-unique-2:hover {
+    background: #f8f9fa;
+}

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -225,3 +225,80 @@ def test_match_counts(ruleset, path, threshold, similar_groups, expected_regions
     assert len(result.similar_groups) == similar_groups
     for region1, region2 in expected_regions:
         _assert_regions_in_same_group(result, region1, region2).similarity > threshold
+
+
+def test_single_region_files_with_identical_blocks():
+    """
+    Test that files treated as 'one region' (CSS, bash, SQL) can detect
+    identical blocks of lines when they meet the min_lines threshold.
+
+    This test creates two CSS files that:
+    - Are mostly different (unique header/footer sections)
+    - Share an identical block of ~15 lines in the middle
+    - Should have that identical block detected by line-level matching
+    """
+    fixture_dir = Path(__file__).parent.parent / "fixtures" / "css"
+    file1 = fixture_dir / "file_with_shared_block_1.css"
+    file2 = fixture_dir / "file_with_shared_block_2.css"
+
+    # Use a low threshold and min_lines to catch the shared block
+    set_settings(
+        PipelineSettings(
+            rules=RulesSettings(ruleset="default"),
+            shingle=ShingleSettings(k=3),
+            minhash=MinHashSettings(num_perm=128),
+            lsh=LSHSettings(
+                threshold=0.3,  # Low threshold to catch partial matches
+                min_lines=5,    # Shared block is ~15 lines
+            ),
+        )
+    )
+
+    result = run_pipeline(fixture_dir)
+
+    # Expected behavior: The shared block (lines ~14-32 in file1, lines ~14-32 in file2)
+    # should be detected either in Level 1 or Level 2
+
+    # Print detailed results for debugging
+    print(f"\n=== Test Results for Single Region Files ===")
+    print(f"Total similar groups found: {len(result.similar_groups)}")
+
+    for i, group in enumerate(result.similar_groups):
+        print(f"\nGroup {i + 1}:")
+        print(f"  Similarity: {group.similarity:.2%}")
+        print(f"  Regions:")
+        for region in group.regions:
+            print(f"    - {region.path.name}:{region.start_line}-{region.end_line} "
+                  f"({region.region_type}) [{region.region_name}]")
+
+    # Find any group that contains regions from both files
+    shared_groups = []
+    for group in result.similar_groups:
+        file1_in_group = any(r.path == file1 for r in group.regions)
+        file2_in_group = any(r.path == file2 for r in group.regions)
+        if file1_in_group and file2_in_group:
+            shared_groups.append(group)
+
+    print(f"\n=== Analysis ===")
+    print(f"Groups containing both files: {len(shared_groups)}")
+
+    if shared_groups:
+        for i, group in enumerate(shared_groups):
+            print(f"\nShared group {i + 1}:")
+            file1_regions = [r for r in group.regions if r.path == file1]
+            file2_regions = [r for r in group.regions if r.path == file2]
+            print(f"  File 1 regions: {file1_regions}")
+            print(f"  File 2 regions: {file2_regions}")
+    else:
+        print("  ISSUE: No shared identical block was detected!")
+        print("  This suggests that single-region files are not being broken down")
+        print("  into smaller line-based chunks for comparison.")
+
+    # This assertion documents the expected behavior
+    # If it fails, it confirms the issue: identical blocks are NOT being detected
+    assert len(shared_groups) > 0, (
+        "Expected to find at least one similarity group containing regions from both files. "
+        "The identical block (shared-button, shared-container, shared-card) should be detected "
+        "by line-level matching, but was not found. This indicates that single-region files "
+        "are not being properly chunked for line-level comparison."
+    )


### PR DESCRIPTION
This commit adds a failing test that demonstrates the issue where files treated as "one region" (CSS, bash, SQL) cannot detect identical blocks when the files as a whole are not similar enough.

The test creates two CSS files that:
- Are mostly different (different header/footer sections)
- Share an identical 22-line block in the middle
- Should have that block detected, but it is NOT

The issue occurs because:
1. Level 1 treats each file as one whole region
2. The files don't match (only ~17% overlap)
3. Level 2 creates ONE line-based region for each entire file
4. This is the same comparison as Level 1 - no chunking occurs

See SINGLE_REGION_ISSUE.md for detailed analysis and potential solutions.

Test files:
- tests/fixtures/css/file_with_shared_block_1.css (132 lines)
- tests/fixtures/css/file_with_shared_block_2.css (153 lines)
- Both share lines with .shared-button, .shared-container, .shared-card