### PR TITLE
Add CSS fixture for code duplication detection

### DIFF
--- a/tests/pipeline/languages/test_css.py
+++ b/tests/pipeline/languages/test_css.py
@@ -14,19 +14,19 @@ from whorl.pipeline.rules.engine import RuleEngine, build_default_rules, build_l
 fixture_comprehensive = Path(__file__).parent.parent.parent / "fixtures" / "css" / "comprehensive.css"
 
 
-@pytest.mark.parametrize("rules", [
-    [],
-    [rule for rule, _ in build_default_rules()],
-    [rule for rule, _ in build_loose_rules()]
+@pytest.mark.parametrize("rules,expected_min_regions", [
+    ([], 1),  # No rules, entire file as one region
+    ([rule for rule, _ in build_default_rules()], 15),  # CSS defines region extraction rules
+    ([rule for rule, _ in build_loose_rules()], 15)  # Same regions with loose rules
 ])
-def test_css_rules_extract(rules):
+def test_css_rules_extract(rules, expected_min_regions):
     """Test that CSS files can be processed with different rule sets."""
     parsed = parse_fixture(fixture_comprehensive, "css")
     engine = RuleEngine(rules)
     regions = extract_all_regions([parsed], engine)
 
-    # CSS doesn't define region extraction rules, so we may get 0 regions
-    assert len(regions) >= 0
+    # CSS now defines region extraction rules for rule_set, media_statement, and keyframes_statement
+    assert len(regions) >= expected_min_regions
 
 
 def test_language_name():

--- a/whorl/config.py
+++ b/whorl/config.py
@@ -1,5 +1,7 @@
 """Configuration using pydantic-settings."""
 
+from typing import Any
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -67,7 +69,7 @@ class LSHSettings(BaseSettings):
     line_threshold: float = 0.3
     line_min_similarity: float = 0.95
 
-    def __init__(self, threshold: float | None = None, **data):
+    def __init__(self, threshold: float | None = None, **data: Any) -> None:
         """Initialize LSH settings, optionally overriding thresholds with a single value."""
         # If threshold is provided, use it for all thresholds (backward compatibility)
         if threshold is not None:

--- a/whorl/pipeline/languages/css.py
+++ b/whorl/pipeline/languages/css.py
@@ -55,4 +55,17 @@ class CSSConfig(LanguageConfig):
         ]
 
     def get_region_extraction_rules(self) -> list[RegionExtractionRule]:
-        return []
+        return [
+            RegionExtractionRule(
+                query="(rule_set) @region",
+                region_type="rule"
+            ),
+            RegionExtractionRule(
+                query="(media_statement) @region",
+                region_type="media"
+            ),
+            RegionExtractionRule(
+                query="(keyframes_statement) @region",
+                region_type="keyframes"
+            ),
+        ]


### PR DESCRIPTION
- Added region extraction rules for CSS (rule_set, media_statement, keyframes_statement)
- Updated test to verify CSS region extraction is working
- Fixed type annotation for LSHSettings.__init__ to satisfy mypy
- whorl detect now properly detects similar CSS code at the rule level