### PR TITLE
Add treesitter subcommand transform display option

### DIFF
--- a/whorl/cli.py
+++ b/whorl/cli.py
@@ -550,6 +550,96 @@ def _extract_tokens_from_file(parsed_file: Any, shingler: Any) -> dict[int, list
     return tokens_by_line
 
 
+def _process_leaf_node(
+    node: Any, node_repr: Any, line_parts: dict[int, list[tuple[int, str]]]
+) -> None:
+    """Process a leaf node and add its representation to line_parts."""
+    line_num = node.start_point[0] + 1
+    col_num = node.start_point[1]
+
+    # Use the normalized representation
+    if node_repr.value:
+        text = f"{node_repr.name}:{node_repr.value}"
+    else:
+        text = node_repr.name
+
+    if line_num not in line_parts:
+        line_parts[line_num] = []
+    line_parts[line_num].append((col_num, text))
+
+
+def _process_internal_node(
+    node: Any, shingler: Any, language: str, source: bytes, root: Any,
+    line_parts: dict[int, list[tuple[int, str]]]
+) -> None:
+    """Process an internal node where all children were skipped."""
+    from whorl.models.normalization import SkipNode
+
+    line_num = node.start_point[0] + 1
+    col_num = node.start_point[1]
+    try:
+        node_repr = shingler._get_node_representation(node, language, source, root)
+        if line_num not in line_parts:
+            line_parts[line_num] = []
+        line_parts[line_num].append((col_num, f"<{node_repr.name}>"))
+    except SkipNode:
+        pass
+
+
+def _reconstruct_lines_from_parts(line_parts: dict[int, list[tuple[int, str]]]) -> dict[int, str]:
+    """Reconstruct source lines from collected node parts."""
+    reconstructed_lines: dict[int, str] = {}
+    for line_num, parts in sorted(line_parts.items()):
+        sorted_parts = sorted(parts, key=lambda x: x[0])
+        reconstructed_lines[line_num] = " ".join(text for _, text in sorted_parts)
+    return reconstructed_lines
+
+
+def _reconstruct_transformed_source(parsed_file: Any, shingler: Any) -> dict[int, str]:
+    """Reconstruct source code from normalized AST nodes, grouped by line number.
+
+    Returns a dictionary mapping line numbers (1-indexed) to reconstructed source lines.
+    """
+    from whorl.models.normalization import SkipNode
+
+    source = parsed_file.source
+    language = parsed_file.language
+    root = parsed_file.root_node
+
+    # Reset identifiers for consistent output
+    shingler.rule_engine.reset_identifiers()
+    shingler.rule_engine.precompute_queries(root, language, source)
+
+    # Track which source bytes have been covered by nodes
+    line_parts: dict[int, list[tuple[int, str]]] = {}
+
+    def traverse(node: Any, parent_skipped: bool = False) -> bool:
+        """Traverse AST and reconstruct source from normalized nodes."""
+        node_skipped = False
+        try:
+            node_repr = shingler._get_node_representation(node, language, source, root)
+            if len(node.children) == 0:
+                _process_leaf_node(node, node_repr, line_parts)
+        except SkipNode:
+            node_skipped = True
+
+        # Process children
+        any_child_processed = False
+        for child in node.children:
+            child_skipped = traverse(child, node_skipped)
+            if not child_skipped:
+                any_child_processed = True
+
+        # For nodes with children that weren't skipped, add structural info if needed
+        if not node_skipped and not any_child_processed and len(node.children) > 0:
+            _process_internal_node(node, shingler, language, source, root, line_parts)
+
+        return node_skipped
+
+    traverse(root)
+    return _reconstruct_lines_from_parts(line_parts)
+
+
 def _truncate_if_needed(text: str, max_width: int) -> str:
     """Truncate text if it exceeds max_width."""
     if len(text) > max_width - 1:
@@ -557,68 +647,92 @@ def _truncate_if_needed(text: str, max_width: int) -> str:
     return text
 
 
-def _print_side_by_side_header(file_path: Any, language: str, col_width: int) -> None:
+def _print_side_by_side_header(file_path: Any, language: str, col_width: int, show_transformed: bool = False) -> None:
     """Print the header for side-by-side display."""
     console.print("\n[bold]TreeSitter Side-by-Side View:[/bold]")
     console.print(f"[bold cyan]File:[/bold cyan] {file_path}")
     console.print(f"[dim]Language: {language}[/dim]")
     header_left = "Original Source"
-    header_right = "TreeSitter Tokens"
+    header_right = "Transformed Source" if show_transformed else "TreeSitter Tokens"
     console.print(f"\n[bold]{header_left:<{col_width}}[/bold]│[bold]{header_right:<{col_width}}[/bold]")
     console.print(f"{'-' * col_width}│{'-' * col_width}")
 
 
-def _display_file_side_by_side(parsed_file: Any, shingler: Any) -> None:
-    """Display original file content side-by-side with treesitter tokens."""
-    # Get original file lines
+def _display_transformed_view(
+    source_lines: list[str], parsed_file: Any, shingler: Any, col_width: int
+) -> None:
+    """Display transformed source view."""
+    transformed_lines = _reconstruct_transformed_source(parsed_file, shingler)
+
+    for line_num in range(1, len(source_lines) + 1):
+        source_line = source_lines[line_num - 1] if line_num <= len(source_lines) else ""
+        left_line = _truncate_if_needed(source_line, col_width)
+        transformed_line = transformed_lines.get(line_num, "")
+        right_line = _truncate_if_needed(transformed_line, col_width)
+        console.print(f"{left_line:<{col_width}}│{right_line:<{col_width}}")
+
+    console.print(f"\n[dim]Total source lines: {len(source_lines)}[/dim]")
+    console.print(f"[dim]Transformed lines: {len(transformed_lines)}[/dim]")
+
+
+def _display_tokens_view(
+    source_lines: list[str], parsed_file: Any, shingler: Any, col_width: int
+) -> None:
+    """Display tree-sitter tokens view."""
+    tokens_by_line = _extract_tokens_from_file(parsed_file, shingler)
+    total_tokens = 0
+
+    for line_num in range(1, len(source_lines) + 1):
+        source_line = source_lines[line_num - 1] if line_num <= len(source_lines) else ""
+        left_line = _truncate_if_needed(source_line, col_width)
+        line_tokens = tokens_by_line.get(line_num, [])
+        total_tokens += len(line_tokens)
+        tokens_str = " ".join(line_tokens)
+        right_line = _truncate_if_needed(tokens_str, col_width)
+        console.print(f"{left_line:<{col_width}}│{right_line:<{col_width}}")
+
+    console.print(f"\n[dim]Total source lines: {len(source_lines)}[/dim]")
+    console.print(f"[dim]Total tokens: {total_tokens}[/dim]")
+
+
+def _display_file_side_by_side(parsed_file: Any, shingler: Any, show_transformed: bool = False) -> None:
+    """Display original file content side-by-side with treesitter tokens or transformed source."""
     try:
         source_lines = parsed_file.source.decode("utf-8", errors="ignore").splitlines()
     except Exception:
         console.print("[bold red]Error:[/bold red] Failed to decode file content")
         return
 
-    # Extract normalized tokens grouped by line
-    tokens_by_line = _extract_tokens_from_file(parsed_file, shingler)
+    col_width = console.width // 2
+    _print_side_by_side_header(parsed_file.path, parsed_file.language, col_width, show_transformed)
 
-    # Calculate column widths
-    terminal_width = console.width
-    col_width = terminal_width // 2
+    if show_transformed:
+        _display_transformed_view(source_lines, parsed_file, shingler, col_width)
+    else:
+        _display_tokens_view(source_lines, parsed_file, shingler, col_width)
 
-    # Print header
-    _print_side_by_side_header(parsed_file.path, parsed_file.language, col_width)
-
-    # Display content side-by-side
-    total_tokens = 0
-    for line_num in range(1, len(source_lines) + 1):
-        # Get source line (0-indexed array, but line_num is 1-indexed)
-        source_line = source_lines[line_num - 1] if line_num <= len(source_lines) else ""
-        left_line = _truncate_if_needed(source_line, col_width)
-
-        # Get all tokens for this line and concatenate them with spaces
-        line_tokens = tokens_by_line.get(line_num, [])
-        total_tokens += len(line_tokens)
-        tokens_str = " ".join(line_tokens)
-        right_line = _truncate_if_needed(tokens_str, col_width)
-
-        console.print(f"{left_line:<{col_width}}│{right_line:<{col_width}}")
-
-    console.print(f"\n[dim]Total source lines: {len(source_lines)}[/dim]")
-    console.print(f"[dim]Total tokens: {total_tokens}[/dim]")
     console.print()
 
 
 @main.command()
 @click.argument("file", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--transformed",
+    is_flag=True,
+    default=False,
+    help="Show transformed source instead of tree-sitter tokens on the right side",
+)
 @click.pass_context
 def treesitter(
     ctx: click.Context,
     file: Path,
+    transformed: bool,
 ) -> None:
     """Show file with side-by-side view of original source and tree-sitter tokens.
 
     This command displays the original source code on the left and the normalized
-    tree-sitter token representations on the right, showing how the code is
-    transformed during similarity detection.
+    tree-sitter token representations on the right (or transformed source with --transformed),
+    showing how the code is transformed during similarity detection.
     """
     from whorl.config import get_settings
     from whorl.pipeline.parse import parse_file
@@ -640,7 +754,7 @@ def treesitter(
     shingler = ASTShingler(rule_engine=rule_engine, k=3)
 
     # Display side-by-side view
-    _display_file_side_by_side(parsed_file, shingler)
+    _display_file_side_by_side(parsed_file, shingler, show_transformed=transformed)
 
 
 @main.command(name="list-ruleset")


### PR DESCRIPTION
This adds a new --transformed flag to the treesitter subcommand that shows the transformed source code on the right side instead of the tree-sitter tokens.

Key changes:
- Added --transformed flag to treesitter command
- Implemented _reconstruct_transformed_source() to rebuild source from normalized AST
- Refactored display logic into separate helper functions to meet complexity standards
- Updated header to show "Transformed Source" when flag is used

The transformed source shows how code looks after applying normalization rules (anonymized identifiers, replaced literals, etc.), helping users understand how the similarity detection algorithm processes the code.

Example usage:
  whorl treesitter --transformed file.py
  whorl --ruleset loose treesitter --transformed file.py