### PR TITLE
Remove stored failed files concept

### DIFF
--- a/tests/pipeline/test_lsh_stage.py
+++ b/tests/pipeline/test_lsh_stage.py
@@ -17,7 +17,7 @@ def test_detect_similarity_1():
         rule_engine=RuleEngine([]),
     )
     signatures = compute_region_signatures(shingled_regions)
-    result = detect_similarity(signatures, 0.1, {}, shingled_regions)
+    result = detect_similarity(signatures, 0.1, shingled_regions)
 
     assert len(result.similar_groups) == 1
     # After verification, the similarity is ~0.22
@@ -35,7 +35,7 @@ def test_detect_similarity_2():
     )
     signatures = compute_region_signatures(shingled_regions)
     # Use lower min_similarity to allow the match through after verification
-    result = detect_similarity(signatures, 0.5, {}, shingled_regions)
+    result = detect_similarity(signatures, 0.5, shingled_regions)
 
     assert len(result.similar_groups) == 1
     assert result.similar_groups[0].similarity > 0.6

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -41,7 +41,7 @@ def test_dissimilar_files():
     )
 
     signatures = compute_region_signatures(shingled_regions)
-    result = detect_similarity(signatures, 0.5, {}, shingled_regions)
+    result = detect_similarity(signatures, 0.5, shingled_regions)
     assert len(result.similar_groups) == 0
 
 

--- a/treepeat/cli/commands/detect.py
+++ b/treepeat/cli/commands/detect.py
@@ -143,18 +143,6 @@ def display_similar_groups(result: SimilarityResult, show_diff: bool = False) ->
         _display_group(group, show_diff=show_diff)
 
 
-def display_failed_files(result: SimilarityResult, show_details: bool) -> None:
-    """Display failed files with optional error details."""
-    if not result.failed_files:
-        return
-
-    console.print("\n[bold red]Failed Files:[/bold red]")
-    for file_path, error in result.failed_files.items():
-        console.print(f"  [red]✗[/red] {file_path}")
-        if show_details:
-            console.print(f"    [dim]{error}[/dim]")
-
-
 def _init_language_stats(
     stats_by_format: dict[str, dict[str, int | set[Path]]], language: str
 ) -> None:
@@ -283,17 +271,15 @@ def _handle_output(
         _write_output(output_text, output_path)
     else:  # console
         display_similar_groups(result, show_diff=show_diff)
-        display_failed_files(result, show_details=(log_level.upper() == "DEBUG"))
         display_summary_table(result)
         console.print()
 
 
 def _check_result_errors(result: SimilarityResult, output_format: str) -> None:
     """Check for errors in the result and exit if necessary."""
-    if result.success_count == 0 and result.failure_count > 0:
+    if result.success_count == 0:
         if output_format.lower() == "console":
             console.print("[bold red]Error:[/bold red] Failed to parse any files")
-            display_failed_files(result, show_details=True)
         sys.exit(1)
 
 

--- a/treepeat/models/ast.py
+++ b/treepeat/models/ast.py
@@ -25,26 +25,16 @@ class ParsedFile(BaseModel):
 class ParseResult(BaseModel):
     """Result of parsing one or more files."""
 
-    model_config = {"arbitrary_types_allowed": True}
-
     parsed_files: list[ParsedFile] = Field(
         default_factory=list, description="Successfully parsed files"
-    )
-    failed_files: dict[Path, str] = Field(
-        default_factory=dict, description="Failed files with error messages"
     )
 
     @property
     def total_files(self) -> int:
         """Total number of files processed."""
-        return len(self.parsed_files) + len(self.failed_files)
+        return len(self.parsed_files)
 
     @property
     def success_count(self) -> int:
         """Number of successfully parsed files."""
         return len(self.parsed_files)
-
-    @property
-    def failure_count(self) -> int:
-        """Number of failed files."""
-        return len(self.failed_files)

--- a/treepeat/models/shingle.py
+++ b/treepeat/models/shingle.py
@@ -64,8 +64,6 @@ class ShingleList(BaseModel):
 class ShingledFile(BaseModel):
     """A file with its extracted shingles."""
 
-    model_config = {"arbitrary_types_allowed": True}
-
     path: Path = Field(description="Path to the source file")
     language: str = Field(description="Programming language of the file")
     shingles: ShingleList = Field(description="Set of shingles extracted from the AST")
@@ -78,8 +76,6 @@ class ShingledFile(BaseModel):
 
 class ShingledRegion(BaseModel):
     """A region with its extracted shingles."""
-
-    model_config = {"arbitrary_types_allowed": True}
 
     region: Region = Field(description="The code region")
     shingles: ShingleList = Field(description="Set of shingles extracted from the region")
@@ -96,21 +92,13 @@ class ShingleResult(BaseModel):
     shingled_files: list[ShingledFile] = Field(
         default_factory=list, description="Successfully shingled files"
     )
-    failed_files: dict[Path, str] = Field(
-        default_factory=dict, description="Files that failed to shingle with error messages"
-    )
 
     @property
     def total_files(self) -> int:
         """Total number of files processed."""
-        return len(self.shingled_files) + len(self.failed_files)
+        return len(self.shingled_files)
 
     @property
     def success_count(self) -> int:
         """Number of successfully shingled files."""
         return len(self.shingled_files)
-
-    @property
-    def failure_count(self) -> int:
-        """Number of files that failed to shingle."""
-        return len(self.failed_files)

--- a/treepeat/models/similarity.py
+++ b/treepeat/models/similarity.py
@@ -86,9 +86,6 @@ class SimilarityResult(BaseModel):
     similar_groups: list[SimilarRegionGroup] = Field(
         default_factory=list, description="Groups of similar regions above threshold"
     )
-    failed_files: dict[Path, str] = Field(
-        default_factory=dict, description="Files that failed processing"
-    )
 
     @property
     def total_regions(self) -> int:
@@ -99,17 +96,12 @@ class SimilarityResult(BaseModel):
     def total_files(self) -> int:
         """Total number of unique files processed."""
         files = {sig.region.path for sig in self.signatures}
-        return len(files) + len(self.failed_files)
+        return len(files)
 
     @property
     def success_count(self) -> int:
         """Number of successfully processed regions."""
         return len(self.signatures)
-
-    @property
-    def failure_count(self) -> int:
-        """Number of files that failed."""
-        return len(self.failed_files)
 
     @property
     def group_count(self) -> int:

--- a/treepeat/pipeline/lsh_stage.py
+++ b/treepeat/pipeline/lsh_stage.py
@@ -1,7 +1,6 @@
 """LSH stage for finding similar region pairs."""
 
 import logging
-from pathlib import Path
 from typing import Hashable
 
 from datasketch import MinHashLSH  # type: ignore[import-untyped]
@@ -341,7 +340,6 @@ def _verify_and_filter_groups(
 def detect_similarity(
     signatures: list[RegionSignature],
     similarity_percent: float,
-    failed_files: dict[Path, str],
     shingled_regions: list[ShingledRegion],
 ) -> SimilarityResult:
     """Detect similar regions using LSH."""
@@ -357,5 +355,4 @@ def detect_similarity(
     return SimilarityResult(
         signatures=signatures,
         similar_groups=similar_groups,
-        failed_files=failed_files or {},
     )

--- a/treepeat/pipeline/parse.py
+++ b/treepeat/pipeline/parse.py
@@ -287,8 +287,7 @@ def parse_files(files: list[Path], result: ParseResult) -> None:
             parsed = parse_file(file_path)
             result.parsed_files.append(parsed)
         except Exception as e:
-            logger.error(f"Failed to parse {file_path}: {e}")
-            result.failed_files[file_path] = str(e)
+            logger.warning(f"Failed to parse {file_path}: {e}")
 
 
 def parse_path(target_path: Path) -> ParseResult:
@@ -299,12 +298,11 @@ def parse_path(target_path: Path) -> ParseResult:
     files = collect_source_files(target_path)
 
     if not files:
-        logger.error(f"Path does not exist or contains no source files: {target_path}")
-        result.failed_files[target_path] = "Path does not exist or contains no source files"
+        logger.warning(f"Path does not exist or contains no source files: {target_path}")
         return result
 
     parse_files(files, result)
 
-    logger.info(f"Parse complete: {result.success_count} succeeded, {result.failure_count} failed")
+    logger.info(f"Parse complete: {result.success_count} succeeded")
 
     return result

--- a/treepeat/pipeline/shingle.py
+++ b/treepeat/pipeline/shingle.py
@@ -197,25 +197,21 @@ def shingle_files(
 
     shingler = ASTShingler(rule_engine=rule_engine, k=k)
     shingled_files = []
-    failed_files = dict(parse_result.failed_files)  # Start with parse failures
 
     for parsed_file in parse_result.parsed_files:
         try:
             shingled_file = shingler.shingle_file(parsed_file)
             shingled_files.append(shingled_file)
         except Exception as e:
-            logger.error("Failed to shingle %s: %s", parsed_file.path, e)
-            failed_files[parsed_file.path] = str(e)
+            logger.warning("Failed to shingle %s: %s", parsed_file.path, e)
 
     logger.info(
-        "Shingling complete: %d succeeded, %d failed",
+        "Shingling complete: %d succeeded",
         len(shingled_files),
-        len(failed_files) - len(parse_result.failed_files),
     )
 
     return ShingleResult(
         shingled_files=shingled_files,
-        failed_files=failed_files,
     )
 
 


### PR DESCRIPTION
Instead of storing failed files in result objects, log warnings when files fail to parse or process. This simplifies the data models and removes unnecessary state tracking.

- Remove failed_files field from SimilarityResult, ParseResult, and ShingleResult
- Update pipeline stages to log warnings instead of collecting failures
- Remove display_failed_files from CLI output
- Remove unused model_config declarations