### PR TITLE
Refactor functions with guard statements

### DIFF
--- a/treepeat/cli/commands/detect.py
+++ b/treepeat/cli/commands/detect.py
@@ -68,14 +68,14 @@ def _write_output(text: str, output_path: Path | None) -> None:
 
 def _run_pipeline_with_ui(path: Path, output_format: str) -> SimilarityResult:
     """Run the pipeline with appropriate UI feedback based on output format."""
-    if output_format.lower() == "console":
-        from treepeat.config import get_settings
-        settings = get_settings()
-        console.print(f"\nRuleset: [cyan]{settings.rules.ruleset}[/cyan]")
-        console.print(f"Analyzing: [cyan]{path}[/cyan]\n")
-        with console.status("[bold green]Running pipeline..."):
-            return run_pipeline(path)
-    else:
+    if output_format.lower() != "console":
+        return run_pipeline(path)
+
+    from treepeat.config import get_settings
+    settings = get_settings()
+    console.print(f"\nRuleset: [cyan]{settings.rules.ruleset}[/cyan]")
+    console.print(f"Analyzing: [cyan]{path}[/cyan]\n")
+    with console.status("[bold green]Running pipeline..."):
         return run_pipeline(path)
 
 
@@ -277,10 +277,13 @@ def _handle_output(
 
 def _check_result_errors(result: SimilarityResult, output_format: str) -> None:
     """Check for errors in the result and exit if necessary."""
-    if result.success_count == 0:
-        if output_format.lower() == "console":
-            console.print("[bold red]Error:[/bold red] Failed to parse any files")
-        sys.exit(1)
+    if result.success_count != 0:
+        return
+
+    if output_format.lower() == "console":
+        console.print("[bold red]Error:[/bold red] Failed to parse any files")
+
+    sys.exit(1)
 
 
 @click.command()

--- a/treepeat/diff.py
+++ b/treepeat/diff.py
@@ -111,25 +111,29 @@ def _print_replaced_lines(lines1: list[str], lines2: list[str], i1: int, i2: int
     """Print replaced (changed) lines side-by-side with character-level diff highlighting."""
     max_len = max(i2 - i1, j2 - j1)
     for idx in range(max_len):
-        if idx < (i2 - i1):
+        has_left = idx < (i2 - i1)
+        has_right = idx < (j2 - j1)
+
+        if has_left and has_right:
             left_line = _truncate_line(lines1[i1 + idx], col_width)
-
-            # If we have a corresponding right line, do character-level diff
-            if idx < (j2 - j1):
-                right_line = _truncate_line(lines2[j1 + idx], col_width)
-                left, right = _highlight_char_diff(left_line, right_line, col_width)
-            else:
-                # No corresponding right line - just soft background full width
-                padding = col_width - len(left_line)
-                left = f"[{_colors.left_bg}]{left_line}{' ' * padding}[/{_colors.left_bg}]"
-                right = f"[{_colors.right_bg}]{' ' * col_width}[/{_colors.right_bg}]"
-        else:
-            # No left line, only right
             right_line = _truncate_line(lines2[j1 + idx], col_width)
-            padding = col_width - len(right_line)
-            left = f"[{_colors.left_bg}]{' ' * col_width}[/{_colors.left_bg}]"
-            right = f"[{_colors.right_bg}]{right_line}{' ' * padding}[/{_colors.right_bg}]"
+            left, right = _highlight_char_diff(left_line, right_line, col_width)
+            console.print(f"{left}│{right}")
+            continue
 
+        if has_left:
+            left_line = _truncate_line(lines1[i1 + idx], col_width)
+            padding = col_width - len(left_line)
+            left = f"[{_colors.left_bg}]{left_line}{' ' * padding}[/{_colors.left_bg}]"
+            right = f"[{_colors.right_bg}]{' ' * col_width}[/{_colors.right_bg}]"
+            console.print(f"{left}│{right}")
+            continue
+
+        # No left line, only right
+        right_line = _truncate_line(lines2[j1 + idx], col_width)
+        padding = col_width - len(right_line)
+        left = f"[{_colors.left_bg}]{' ' * col_width}[/{_colors.left_bg}]"
+        right = f"[{_colors.right_bg}]{right_line}{' ' * padding}[/{_colors.right_bg}]"
         console.print(f"{left}│{right}")
 
 

--- a/treepeat/formatters/sarif.py
+++ b/treepeat/formatters/sarif.py
@@ -26,10 +26,8 @@ def format_as_sarif(result: SimilarityResult, *, pretty: bool = True) -> str:
     """Format similarity detection results as SARIF JSON. """
     sarif_log = _create_sarif_log(result)
 
-    if pretty:
-        json_output: str = sarif_log.model_dump_json(indent=2, exclude_none=True)
-        return json_output
-    json_output = sarif_log.model_dump_json(exclude_none=True)
+    indent = 2 if pretty else None
+    json_output: str = sarif_log.model_dump_json(indent=indent, exclude_none=True)
     return json_output
 
 

--- a/treepeat/pipeline/auto_chunk_extraction.py
+++ b/treepeat/pipeline/auto_chunk_extraction.py
@@ -67,10 +67,7 @@ def _find_leaf_chunks(root: Node, min_lines: int) -> list[Node]:
             return False
 
         # Check if any children are large enough to be chunks
-        has_chunk_children = False
-        for child in node.children:
-            if traverse(child):
-                has_chunk_children = True
+        has_chunk_children = any(traverse(child) for child in node.children)
 
         # If no children are chunks, this node is a leaf chunk
         if not has_chunk_children:
@@ -80,9 +77,7 @@ def _find_leaf_chunks(root: Node, min_lines: int) -> list[Node]:
                 node.type,
                 node_lines,
             )
-            return True
 
-        # Otherwise, we've already processed children, this node is not a chunk
         return True
 
     traverse(root)

--- a/treepeat/pipeline/lsh_stage.py
+++ b/treepeat/pipeline/lsh_stage.py
@@ -345,12 +345,15 @@ def detect_similarity(
     """Detect similar regions using LSH."""
     candidate_groups = find_similar_groups(signatures, similarity_percent)
 
-    if len(candidate_groups) > 0:
-        similar_groups = _verify_and_filter_groups(
-            candidate_groups, shingled_regions, similarity_percent
+    if not candidate_groups:
+        return SimilarityResult(
+            signatures=signatures,
+            similar_groups=[],
         )
-    else:
-        similar_groups = candidate_groups
+
+    similar_groups = _verify_and_filter_groups(
+        candidate_groups, shingled_regions, similarity_percent
+    )
 
     return SimilarityResult(
         signatures=signatures,


### PR DESCRIPTION
Apply early return guard statements to reduce nesting levels across multiple functions in the codebase, improving readability:

- detect.py: _check_result_errors, _run_pipeline_with_ui
- lsh_stage.py: detect_similarity
- sarif.py: format_as_sarif
- diff.py: _print_replaced_lines
- terminal_detect.py: _detect_via_osc11
- auto_chunk_extraction.py: traverse