### PR TITLE
Limit region extraction to largest files

### DIFF
--- a/treepeat/config.py
+++ b/treepeat/config.py
@@ -56,14 +56,14 @@ class LSHSettings(BaseSettings):
         description="Minimum number of lines for a match to be considered valid",
     )
 
-    max_lines_per_language: int = Field(
-        default=1000,
+    max_files_per_language: int = Field(
+        default=5,
         ge=1,
-        description="Maximum total lines to sample per language for region extraction",
+        description="Maximum number of files per language to extract regions from (largest files prioritized)",
     )
 
     max_lines_per_file: int = Field(
-        default=300,
+        default=500,
         ge=1,
         description="Maximum lines to read from any single file during region extraction",
     )

--- a/treepeat/config.py
+++ b/treepeat/config.py
@@ -56,6 +56,18 @@ class LSHSettings(BaseSettings):
         description="Minimum number of lines for a match to be considered valid",
     )
 
+    max_lines_per_language: int = Field(
+        default=1000,
+        ge=1,
+        description="Maximum total lines to sample per language for region extraction",
+    )
+
+    max_lines_per_file: int = Field(
+        default=300,
+        ge=1,
+        description="Maximum lines to read from any single file during region extraction",
+    )
+
     similarity_percent: float = Field(default=0.8, ge=0.0, le=1.0, description="% treesitter similarity")
 
     ignore_node_types: list[str] = Field(

--- a/treepeat/pipeline/region_extraction.py
+++ b/treepeat/pipeline/region_extraction.py
@@ -1,7 +1,8 @@
 """Extract regions (functions, classes, sections, etc) from parsed files."""
 
 import logging
-from collections import Counter
+import random
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 
 from pydantic import BaseModel, Field
@@ -198,6 +199,62 @@ def _log_region_type_statistics(regions: list[ExtractedRegion], method: str) -> 
         logger.info("  ... and %d more type(s)", len(type_counts) - 10)
 
 
+def _count_lines(source: bytes) -> int:
+    """Count lines in source bytes."""
+    return source.count(b'\n') + (1 if source and not source.endswith(b'\n') else 0)
+
+
+def _select_files_up_to_budget(
+    files: list[ParsedFile], max_lines: int, max_lines_per_file: int
+) -> tuple[list[ParsedFile], int]:
+    """Select files from a shuffled list up to the line budget."""
+    selected: list[ParsedFile] = []
+    total_lines = 0
+
+    for pf in files:
+        file_lines = min(_count_lines(pf.source), max_lines_per_file)
+        if total_lines + file_lines > max_lines and selected:
+            break
+        selected.append(pf)
+        total_lines += file_lines
+
+    return selected, total_lines
+
+
+def _sample_files_by_lines(
+    parsed_files: list[ParsedFile], max_lines: int, max_lines_per_file: int
+) -> list[ParsedFile]:
+    """Sample files randomly until reaching max_lines budget per language."""
+    if not parsed_files:
+        return parsed_files
+
+    # Group files by language
+    files_by_language: defaultdict[str, list[ParsedFile]] = defaultdict(list)
+    for pf in parsed_files:
+        files_by_language[pf.language].append(pf)
+
+    # Sample from each language group
+    sampled: list[ParsedFile] = []
+    for language, files in files_by_language.items():
+        shuffled = files.copy()
+        random.shuffle(shuffled)
+
+        selected, total_lines = _select_files_up_to_budget(shuffled, max_lines, max_lines_per_file)
+        sampled.extend(selected)
+
+        if len(selected) < len(files):
+            logger.info(
+                "Sampled %d of %d %s files (~%d lines, max %d/file)",
+                len(selected),
+                len(files),
+                language,
+                total_lines,
+                max_lines_per_file,
+            )
+
+    return sampled
+
+
 def extract_all_regions(
     parsed_files: list[ParsedFile],
     rule_engine: "RuleEngine",
@@ -207,15 +264,31 @@ def extract_all_regions(
     Hybrid extraction combines:
     - Explicit rules (semantic labels like "function", "class")
     - Statistical auto-chunking (discovers patterns rules miss)
+
+    Files are randomly sampled up to a line budget per language for performance.
     """
     from treepeat.pipeline.statistical_chunk_extraction import extract_chunks_statistical
 
     settings = get_settings()
     logger.info("Using hybrid region extraction (explicit + statistical)")
 
+    # Sample files by line budget for performance
+    filtered_files = _sample_files_by_lines(
+        parsed_files,
+        settings.lsh.max_lines_per_language,
+        settings.lsh.max_lines_per_file,
+    )
+    logger.info(
+        "Processing %d of %d files (max %d lines/lang, %d lines/file)",
+        len(filtered_files),
+        len(parsed_files),
+        settings.lsh.max_lines_per_language,
+        settings.lsh.max_lines_per_file,
+    )
+
     all_regions: list[ExtractedRegion] = []
 
-    for parsed_file in parsed_files:
+    for parsed_file in filtered_files:
         try:
             # Get explicit regions from rules
             explicit_regions = extract_regions(parsed_file, rule_engine)
@@ -242,7 +315,7 @@ def extract_all_regions(
             logger.error("Failed to extract regions from %s: %s", parsed_file.path, e)
 
     # Log overall statistics
-    logger.info("Extracted %d total region(s) from %d file(s)", len(all_regions), len(parsed_files))
+    logger.info("Extracted %d total region(s) from %d file(s)", len(all_regions), len(filtered_files))
     _log_region_type_statistics(all_regions, "hybrid")
 
     return all_regions


### PR DESCRIPTION
Add line-based sampling for region extraction:
- max_lines_per_language (default 1000): total line budget per language
- max_lines_per_file (default 300): cap on lines read from any file

Randomly samples files until hitting the line budget, avoiding processing giant files while getting diverse coverage.