### PR TITLE
Add Rust support with structural normalization rules

### DIFF
--- a/tests/fixtures/rust/comprehensive.rs
+++ b/tests/fixtures/rust/comprehensive.rs
@@ -1,0 +1,155 @@
+use std::collections::HashMap;
+
+extern crate serde;
+
+// Shape types for area/perimeter calculation
+/// A circle defined by its radius.
+#[derive(Debug, Clone)]
+pub struct Circle {
+    pub radius: f64,
+    pub color: String,
+}
+
+/// A rectangle defined by its dimensions.
+#[derive(Debug, Clone)]
+pub struct Rectangle {
+    pub width: f64,
+    pub height: f64,
+    pub color: String,
+}
+
+pub trait Shape {
+    fn area(&self) -> f64;
+    fn perimeter(&self) -> f64;
+}
+
+impl Shape for Circle {
+    /* Compute circle area */
+    fn area(&self) -> f64 {
+        std::f64::consts::PI * self.radius * self.radius
+    }
+
+    fn perimeter(&self) -> f64 {
+        2.0 * std::f64::consts::PI * self.radius
+    }
+}
+
+impl Shape for Rectangle {
+    // Structurally similar to Circle::area but different formula
+    fn area(&self) -> f64 {
+        self.width * self.height
+    }
+
+    fn perimeter(&self) -> f64 {
+        2.0 * (self.width + self.height)
+    }
+}
+
+/// Sums all elements of a slice of integers.
+pub fn calculate_sum(numbers: &[i32]) -> i32 {
+    let mut total = 0;
+    for num in numbers {
+        total += num;
+    }
+    total
+}
+
+/// Multiplies all elements of a slice of integers.
+pub fn calculate_product(numbers: &[i32]) -> i32 {
+    let mut product = 1;
+    for num in numbers {
+        product *= num;
+    }
+    product
+}
+
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+/// Returns the Fibonacci number at position n (recursive).
+pub fn fibonacci(n: u32) -> u64 {
+    if n <= 1 {
+        return n as u64;
+    }
+    fibonacci(n - 1) + fibonacci(n - 2)
+}
+
+/// Returns the Fibonacci number at position n (iterative).
+pub fn fibonacci_iterative(n: u32) -> u64 {
+    if n <= 1 {
+        return n as u64;
+    }
+    let mut a: u64 = 0;
+    let mut b: u64 = 1;
+    for _ in 2..=n {
+        let tmp = a + b;
+        a = b;
+        b = tmp;
+    }
+    b
+}
+
+/// Searches a slice linearly for a target value, returning its index.
+pub fn search_linear(arr: &[i32], target: i32) -> Option<usize> {
+    for (i, &val) in arr.iter().enumerate() {
+        if val == target {
+            return Some(i);
+        }
+    }
+    None
+}
+
+/// A unique function with no structural counterpart.
+pub fn build_index(items: &[String]) -> HashMap<String, usize> {
+    let mut index = HashMap::new();
+    for (i, item) in items.iter().enumerate() {
+        index.insert(item.clone(), i);
+    }
+    index
+}
+
+/// Exercises match expressions and enum variants.
+pub fn color_to_hex(color: Color) -> &'static str {
+    match color {
+        Color::Red => "#FF0000",
+        Color::Green => "#00FF00",
+        Color::Blue => "#0000FF",
+    }
+}
+
+/// Generic function — exercises type parameter syntax.
+pub fn find_max<T: PartialOrd>(items: &[T]) -> Option<&T> {
+    let mut max = items.first()?;
+    for item in items.iter() {
+        if item > max {
+            max = item;
+        }
+    }
+    Some(max)
+}
+
+/// Exercises explicit non-static lifetime annotation.
+pub fn first_word<'a>(s: &'a str) -> &'a str {
+    match s.find(' ') {
+        Some(i) => &s[..i],
+        None => s,
+    }
+}
+
+/// Async function — exercises the async fn syntax.
+pub async fn fetch_value(key: &str) -> Option<String> {
+    if key.is_empty() {
+        return None;
+    }
+    Some(key.to_uppercase())
+}
+
+/// Exercises macro_rules! definitions as an extraction target.
+macro_rules! assert_some {
+    ($expr:expr) => {
+        assert!($expr.is_some(), "expected Some, got None");
+    };
+}

--- a/tests/pipeline/languages/test_rust.py
+++ b/tests/pipeline/languages/test_rust.py
@@ -1,0 +1,135 @@
+"""Tests for Rust language configuration and rules."""
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import parse_fixture
+from treepeat.pipeline.languages.rust import RustConfig
+from treepeat.pipeline.region_extraction import extract_all_regions
+from treepeat.pipeline.rules.engine import RuleEngine, build_default_rules, build_loose_rules
+
+
+# Fixture path
+fixture_comprehensive = (
+    Path(__file__).parent.parent.parent / "fixtures" / "rust" / "comprehensive.rs"
+)
+
+
+@pytest.mark.parametrize(
+    "rules",
+    [[rule for rule, _ in build_default_rules()], [rule for rule, _ in build_loose_rules()]],
+)
+def test_rust_rules_extract(rules):
+    """Test that Rust files can be processed with different rule sets."""
+    parsed = parse_fixture(fixture_comprehensive, "rust")
+    engine = RuleEngine(rules)
+    regions = extract_all_regions([parsed], engine)
+
+    # All six extraction types must be present
+    region_types = {r.region.region_type for r in regions}
+    assert region_types == {
+        "function_item", "impl_item", "struct_item",
+        "enum_item", "trait_item", "macro_definition",
+    }
+
+
+def test_language_name():
+    """Test that Rust config returns correct language name."""
+    assert RustConfig().get_language_name() == "rust"
+
+
+def test_lifetime_names_do_not_affect_similarity():
+    """Functions that differ only in lifetime parameter names must produce identical shingles.
+
+    'a and 'b are α-equivalent-ish; renaming them should not affect duplicate detection.
+    'static is intentionally excluded from this rule and is verified in test_rust_rules.py.
+    """
+    from treepeat.pipeline.parse import parse_source_code
+    from treepeat.pipeline.shingle import ASTShingler
+    from treepeat.pipeline.region_extraction import ExtractedRegion
+    from treepeat.models.similarity import Region
+
+    def shingle_source(source: str) -> list[str]:
+        source_bytes = source.encode("utf-8")
+        parsed = parse_source_code(source_bytes, "rust", Path("test.rs"))
+        rules = [rule for rule, _ in build_loose_rules()]
+        engine = RuleEngine(rules)
+        region = Region(
+            path=Path("test.rs"),
+            language="rust",
+            region_type="lines",
+            region_name="test",
+            start_line=1,
+            end_line=source.count("\n") + 1,
+        )
+        extracted = ExtractedRegion(region=region, node=parsed.root_node)
+        engine.reset_identifiers()
+        engine.precompute_queries(extracted.node, "rust", source_bytes)
+        shingler = ASTShingler(rule_engine=engine, k=2)
+        return shingler.shingle_region(extracted, source_bytes).shingles.get_contents()
+
+    shingles_a = shingle_source("fn foo<'a>(x: &'a str) -> &'a str { x }")
+    shingles_b = shingle_source("fn foo<'b>(x: &'b str) -> &'b str { x }")
+
+    assert shingles_a == shingles_b
+
+
+def test_rust_specific_rules():
+    """Test that Rust-specific default rules (use, comments, attributes) work."""
+    from treepeat.pipeline.parse import parse_source_code
+    from treepeat.pipeline.shingle import ASTShingler
+    from treepeat.pipeline.region_extraction import ExtractedRegion
+    from treepeat.models.similarity import Region
+
+    source = b"""
+#![allow(dead_code)]
+use std::collections::HashMap;
+extern crate serde;
+// line comment
+/// doc comment
+/* block comment */
+#[derive(Debug, Clone)]
+pub struct Foo {
+    pub x: i32,
+}
+impl Foo {
+    pub fn new(x: i32) -> Self {
+        Foo { x }
+    }
+}
+"""
+
+    parsed = parse_source_code(source, "rust", Path("test.rs"))
+    rules = [rule for rule, _ in build_default_rules()]
+    engine = RuleEngine(rules)
+
+    region = Region(
+        path=Path("test.rs"),
+        language="rust",
+        region_type="lines",
+        region_name="test",
+        start_line=1,
+        end_line=source.count(b"\n") + 1,
+    )
+    extracted_region = ExtractedRegion(region=region, node=parsed.root_node)
+
+    shingler = ASTShingler(rule_engine=engine, k=2)
+    shingler.rule_engine.reset_identifiers()
+    shingler.rule_engine.precompute_queries(extracted_region.node, "rust", source)
+    shingled = shingler.shingle_region(extracted_region, source)
+
+    shingle_str = " ".join(shingled.shingles.get_contents())
+
+    # Noise should be removed
+    assert "use_declaration" not in shingle_str
+    assert "extern_crate_declaration" not in shingle_str
+    assert "line_comment" not in shingle_str
+    assert "block_comment" not in shingle_str
+    assert "attribute_item" not in shingle_str
+    assert "inner_attribute_item" not in shingle_str
+
+    # Structural elements should remain
+    assert "struct_item" in shingle_str
+    assert "impl_item" in shingle_str
+    assert "function_item" in shingle_str

--- a/tests/pipeline/languages/test_rust_rules.py
+++ b/tests/pipeline/languages/test_rust_rules.py
@@ -1,0 +1,171 @@
+from treepeat.pipeline.languages.rust import RustConfig
+
+
+def test_rust_rules_detailed(rule_tester):
+    config = RustConfig()
+    rule_tester.verify_rules(
+        config,
+        [
+            {
+                "rule_name": "Ignore use declarations",
+                "source": "use std::collections::HashMap;",
+                "expected_symbol": None,
+                "unexpected_symbol": "use_declaration",
+            },
+            {
+                "rule_name": "Ignore extern crate declarations",
+                "source": "extern crate serde;",
+                "expected_symbol": None,
+                "unexpected_symbol": "extern_crate_declaration",
+            },
+            {
+                "rule_name": "Ignore line comments",
+                "source": "// line comment\n/// doc comment",
+                "expected_symbol": None,
+                "unexpected_symbol": "line_comment",
+            },
+            {
+                "rule_name": "Ignore block comments",
+                "source": "/* block\n   comment */",
+                "expected_symbol": None,
+                "unexpected_symbol": "block_comment",
+            },
+            {
+                "rule_name": "Anonymize macro names",
+                "source": 'fn f() { println!("hello"); }',
+                "expected_symbol": None,
+                "unexpected_symbol": "println",
+            },
+            {
+                "rule_name": "Anonymize macro names",
+                "source": "fn f() { log::info!(\"msg\"); log::debug!(\"msg\"); }",
+                "expected_symbol": None,
+                "unexpected_symbol": "info",
+            },
+            {
+                "rule_name": "Ignore attribute items",
+                "source": "#[derive(Debug, Clone)]\nstruct Foo {}",
+                "expected_symbol": None,
+                "unexpected_symbol": "attribute_item",
+            },
+            {
+                "rule_name": "Ignore attribute items",
+                "source": "#![allow(dead_code)]\nfn f() {}",
+                "expected_symbol": None,
+                "unexpected_symbol": "inner_attribute_item",
+            },
+            {
+                # tree-sitter-rust represents 'a as a `lifetime` node (non-leaf) containing
+                # a `'` token and an `identifier` child. Removing the `lifetime` node drops
+                # the whole subtree, so we check for the node-type token "lifetime".
+                "rule_name": "Omit non-static lifetimes",
+                "source": "fn foo<'a>(x: &'a str) -> &'a str { x }",
+                "expected_symbol": None,
+                "unexpected_symbol": "lifetime",
+            },
+            {
+                # 'static must NOT be removed: it carries semantic content (permanent
+                # storage duration), so the `lifetime` node must remain in the shingles.
+                "rule_name": "Omit non-static lifetimes",
+                "source": 'fn foo() -> &\'static str { "hello" }',
+                "expected_symbol": "lifetime",
+                "unexpected_symbol": None,
+            },
+            {
+                "rule_name": "Ignore generic lifetimes",
+                "source": "fn f<'a>(x: &'a i32) {}",
+                "expected_symbol": None,
+                "unexpected_symbol": "lifetime",
+            },
+            {
+                "rule_name": "Ignore generic lifetimes",
+                "source": "fn f(x: &'static i32) {}",
+                "expected_symbol": "static",
+                "unexpected_symbol": None,
+            },
+            {
+                "rule_name": "Anonymize function names",
+                "source": "fn my_func(a: i32) -> i32 { a }",
+                "expected_symbol": "FUNC",
+                "unexpected_symbol": "my_func",
+            },
+            {
+                "rule_name": "Anonymize type names",
+                "source": "struct MyStruct { x: i32 }",
+                "expected_symbol": "TYPE",
+                "unexpected_symbol": "MyStruct",
+            },
+            {
+                "rule_name": "Anonymize type names",
+                "source": "enum MyEnum { Red, Blue }",
+                "expected_symbol": "TYPE",
+                "unexpected_symbol": "MyEnum",
+            },
+            {
+                "rule_name": "Anonymize type names",
+                "source": "trait MyTrait { fn speak(&self) -> String; }",
+                "expected_symbol": "TYPE",
+                "unexpected_symbol": "MyTrait",
+            },
+            {
+                "rule_name": "Anonymize type names",
+                "source": "type MyAlias = Vec<i32>;",
+                "expected_symbol": "TYPE",
+                "unexpected_symbol": "MyAlias",
+            },
+            {
+                "rule_name": "Anonymize type names",
+                "source": "union MyUnion { x: i32, y: f32 }",
+                "expected_symbol": "TYPE",
+                "unexpected_symbol": "MyUnion",
+            },
+            {
+                "rule_name": "Anonymize identifiers",
+                "source": "static MYVAR: i32 = 1;",
+                "expected_symbol": "VAR_1",
+                "unexpected_symbol": "MYVAR",
+            },
+            {
+                "rule_name": "Ignore string content",
+                "source": 'fn f() { let s = "hello world"; }',
+                "expected_symbol": None,
+                "unexpected_symbol": "hello",
+            },
+            {
+                "rule_name": "Anonymize string literals",
+                "source": 'fn f() { let s = "hello"; }',
+                "expected_symbol": "<STR>",
+                "unexpected_symbol": None,
+            },
+            {
+                "rule_name": "Anonymize string literals",
+                "source": "fn f() { let c = 'x'; }",
+                "expected_symbol": "<STR>",
+                "unexpected_symbol": "x",
+            },
+            {
+                "rule_name": "Anonymize numeric literals",
+                "source": "fn f() { let n = 42; let pi = 3.14; }",
+                "expected_symbol": "<NUM>",
+                "unexpected_symbol": "42",
+            },
+            {
+                "rule_name": "Anonymize boolean literals",
+                "source": "fn f() { let b = true; }",
+                "expected_symbol": "<BOOL>",
+                "unexpected_symbol": None,
+            },
+            {
+                "rule_name": "Anonymize binary expressions",
+                "source": "fn f(a: i32, b: i32) -> i32 { a + b }",
+                "expected_symbol": "<BINOP>",
+                "unexpected_symbol": "binary_expression",
+            },
+            {
+                "rule_name": "Anonymize unary expressions",
+                "source": "fn f() { let x = -1; }",
+                "expected_symbol": "<UNOP>",
+                "unexpected_symbol": "unary_expression",
+            },
+        ],
+    )

--- a/tests/pipeline/languages/test_rust_rules.py
+++ b/tests/pipeline/languages/test_rust_rules.py
@@ -1,6 +1,21 @@
 from treepeat.pipeline.languages.rust import RustConfig
 
 
+def test_macro_names_mode_separation(rule_tester):
+    config = RustConfig()
+    source = 'fn f() { println!("hello"); }'
+    # preserved in default mode
+    rule_tester._verify_with_rules(
+        config, config.get_default_rules(),
+        "Anonymize macro names", source, "println", None, "Default Rules"
+    )
+    # removed in loose mode
+    rule_tester._verify_with_rules(
+        config, config.get_loose_rules(),
+        "Anonymize macro names", source, None, "println", "Loose Rules"
+    )
+
+
 def test_rust_rules_detailed(rule_tester):
     config = RustConfig()
     rule_tester.verify_rules(
@@ -53,23 +68,6 @@ def test_rust_rules_detailed(rule_tester):
                 "source": "#![allow(dead_code)]\nfn f() {}",
                 "expected_symbol": None,
                 "unexpected_symbol": "inner_attribute_item",
-            },
-            {
-                # tree-sitter-rust represents 'a as a `lifetime` node (non-leaf) containing
-                # a `'` token and an `identifier` child. Removing the `lifetime` node drops
-                # the whole subtree, so we check for the node-type token "lifetime".
-                "rule_name": "Omit non-static lifetimes",
-                "source": "fn foo<'a>(x: &'a str) -> &'a str { x }",
-                "expected_symbol": None,
-                "unexpected_symbol": "lifetime",
-            },
-            {
-                # 'static must NOT be removed: it carries semantic content (permanent
-                # storage duration), so the `lifetime` node must remain in the shingles.
-                "rule_name": "Omit non-static lifetimes",
-                "source": 'fn foo() -> &\'static str { "hello" }',
-                "expected_symbol": "lifetime",
-                "unexpected_symbol": None,
             },
             {
                 "rule_name": "Ignore generic lifetimes",

--- a/treepeat/pipeline/languages/__init__.py
+++ b/treepeat/pipeline/languages/__init__.py
@@ -12,6 +12,7 @@ from .markdown import MarkdownConfig
 from .go import GoConfig
 from .java import JavaConfig
 from .kotlin import KotlinConfig
+from .rust import RustConfig
 
 # Registry mapping language names to their configurations
 LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
@@ -28,6 +29,7 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
     "go": GoConfig(),
     "java": JavaConfig(),
     "kotlin": KotlinConfig(),
+    "rust": RustConfig(),
 }
 
 LANGUAGE_EXTENSIONS: dict[SupportedLanguage, list[str]] = {
@@ -42,6 +44,7 @@ LANGUAGE_EXTENSIONS: dict[SupportedLanguage, list[str]] = {
     "go": [".go"],
     "java": [".java"],
     "kotlin": [".kt", ".kts"],
+    "rust": [".rs"],
 }
 
 __all__ = [

--- a/treepeat/pipeline/languages/rust.py
+++ b/treepeat/pipeline/languages/rust.py
@@ -1,0 +1,174 @@
+from treepeat.pipeline.rules.models import Rule, RuleAction
+
+from .base import LanguageConfig, RegionExtractionRule
+
+
+class RustConfig(LanguageConfig):
+    """Configuration for Rust language."""
+
+    def get_language_name(self) -> str:
+        return "rust"
+
+    def get_default_rules(self) -> list[Rule]:
+        return [
+            Rule(
+                name="Ignore use declarations",
+                languages=["rust"],
+                query="(use_declaration) @use",
+                action=RuleAction.REMOVE,
+            ),
+            Rule(
+                name="Ignore extern crate declarations",
+                languages=["rust"],
+                query="(extern_crate_declaration) @extern_crate",
+                action=RuleAction.REMOVE,
+            ),
+            Rule(
+                name="Ignore generic lifetimes",
+                languages=["rust"],
+                # Matches any lifetime node that is NOT exactly 'static
+                query='((lifetime) @life (#not-eq? @life "\'static"))',
+                action=RuleAction.REMOVE,
+            ),
+            Rule(
+                name="Ignore line comments",
+                languages=["rust"],
+                query="(line_comment) @comment",
+                action=RuleAction.REMOVE,
+            ),
+            Rule(
+                name="Ignore block comments",
+                languages=["rust"],
+                query="(block_comment) @comment",
+                action=RuleAction.REMOVE,
+            ),
+            Rule(
+                # Covers both outer (#[...]) and inner (#![...]) attribute forms.
+                # Inner attributes are a distinct node type in tree-sitter-rust.
+                name="Ignore attribute items",
+                languages=["rust"],
+                query="[(attribute_item) (inner_attribute_item)] @attr",
+                action=RuleAction.REMOVE,
+            ),
+            Rule(
+                # Removes the macro path before `!` for both simple (`println!`)
+                # and scoped (`log::info!`) forms, so calls differing only in
+                # macro name (e.g. log level) normalize identically. The `!`
+                # delimiter and token_tree arguments are preserved, so the
+                # presence and arity of the call still contributes to similarity.
+                # Note: tree-sitter-rust parses token_tree contents as structured
+                # nodes (string_literal, identifier, etc.), so the existing
+                # string-content and identifier rules already reach inside macro
+                # arguments.
+                name="Anonymize macro names",
+                languages=["rust"],
+                query="[(macro_invocation (identifier) @name) (macro_invocation (scoped_identifier) @name)]",
+                action=RuleAction.REMOVE,
+            ),
+            Rule(
+                # Lifetimes are borrow-checker annotations, not logic — omit non-static ones
+                # so that copy-pasted functions with renamed lifetime parameters ('a → 'b) are
+                # still detected as duplicates. 'static is preserved because it carries semantic
+                # content (permanent storage duration), unlike named lifetimes.
+                name="Omit non-static lifetimes",
+                languages=["rust"],
+                query="""((lifetime) @life (#not-eq? @life "'static"))""",
+                action=RuleAction.REMOVE,
+            ),
+            Rule(
+                name="Anonymize function names",
+                languages=["rust"],
+                query="(function_item name: (identifier) @func)",
+                action=RuleAction.REPLACE_VALUE,
+                params={"value": "FUNC"},
+            ),
+            Rule(
+                # Covers struct, enum, trait, type alias, and union item names.
+                # Note: type_identifier nodes inside impl_item (e.g. `impl Foo`)
+                # are intentionally NOT anonymized — doing so would collapse
+                # impl blocks for unrelated types that happen to have similar
+                # method bodies, producing false-positive clone matches.
+                name="Anonymize type names",
+                languages=["rust"],
+                query="""[
+                    (struct_item name: (type_identifier) @type)
+                    (enum_item name: (type_identifier) @type)
+                    (trait_item name: (type_identifier) @type)
+                    (type_item name: (type_identifier) @type)
+                    (union_item name: (type_identifier) @type)
+                ]""",
+                action=RuleAction.REPLACE_VALUE,
+                params={"value": "TYPE"},
+            ),
+        ]
+
+    def get_loose_rules(self) -> list[Rule]:
+        return [
+            Rule(
+                name="Ignore string content",
+                languages=["rust"],
+                query="(string_content) @content",
+                action=RuleAction.REMOVE,
+            ),
+            Rule(
+                name="Anonymize identifiers",
+                languages=["rust"],
+                query='((identifier) @var (#not-eq? @var "static"))',
+                action=RuleAction.ANONYMIZE,
+                params={"prefix": "VAR"},
+            ),
+            Rule(
+                # Covers regular strings, raw strings, and character literals.
+                # byte strings (b"...") parse as string_literal and are included.
+                # Note: string_content child nodes must be removed separately by
+                # the "Ignore string content" rule to prevent content from leaking.
+                name="Anonymize string literals",
+                languages=["rust"],
+                query="[(string_literal) (raw_string_literal) (char_literal)] @str",
+                action=RuleAction.REPLACE_VALUE,
+                params={"value": "<STR>"},
+            ),
+            Rule(
+                name="Anonymize numeric literals",
+                languages=["rust"],
+                query="[(integer_literal) (float_literal)] @num",
+                action=RuleAction.REPLACE_VALUE,
+                params={"value": "<NUM>"},
+            ),
+            Rule(
+                name="Anonymize boolean literals",
+                languages=["rust"],
+                query="(boolean_literal) @bool",
+                action=RuleAction.REPLACE_VALUE,
+                params={"value": "<BOOL>"},
+            ),
+            Rule(
+                # Covers arithmetic, comparison, logical, and bitwise operators.
+                # compound_assignment_expr (+=, -=, etc.) is a separate node type
+                # and is not anonymized here. The same gap exists in Go and Python
+                # configs and is accepted as a known limitation.
+                name="Anonymize binary expressions",
+                languages=["rust"],
+                query="(binary_expression) @binop",
+                action=RuleAction.REPLACE_NODE_TYPE,
+                params={"token": "<BINOP>"},
+            ),
+            Rule(
+                name="Anonymize unary expressions",
+                languages=["rust"],
+                query="(unary_expression) @unop",
+                action=RuleAction.REPLACE_NODE_TYPE,
+                params={"token": "<UNOP>"},
+            ),
+            *self.get_default_rules(),
+        ]
+
+    def get_region_extraction_rules(self) -> list[RegionExtractionRule]:
+        return [
+            RegionExtractionRule.from_node_type("function_item"),
+            RegionExtractionRule.from_node_type("impl_item"),
+            RegionExtractionRule.from_node_type("struct_item"),
+            RegionExtractionRule.from_node_type("enum_item"),
+            RegionExtractionRule.from_node_type("trait_item"),
+            RegionExtractionRule.from_node_type("macro_definition"),
+        ]

--- a/treepeat/pipeline/languages/rust.py
+++ b/treepeat/pipeline/languages/rust.py
@@ -24,9 +24,12 @@ class RustConfig(LanguageConfig):
                 action=RuleAction.REMOVE,
             ),
             Rule(
+                # Lifetimes are borrow-checker annotations, not logic — omit non-static ones
+                # so that copy-pasted functions with renamed lifetime parameters ('a → 'b) are
+                # still detected as duplicates. 'static is preserved because it carries semantic
+                # content (permanent storage duration), unlike named lifetimes.
                 name="Ignore generic lifetimes",
                 languages=["rust"],
-                # Matches any lifetime node that is NOT exactly 'static
                 query='((lifetime) @life (#not-eq? @life "\'static"))',
                 action=RuleAction.REMOVE,
             ),
@@ -48,31 +51,6 @@ class RustConfig(LanguageConfig):
                 name="Ignore attribute items",
                 languages=["rust"],
                 query="[(attribute_item) (inner_attribute_item)] @attr",
-                action=RuleAction.REMOVE,
-            ),
-            Rule(
-                # Removes the macro path before `!` for both simple (`println!`)
-                # and scoped (`log::info!`) forms, so calls differing only in
-                # macro name (e.g. log level) normalize identically. The `!`
-                # delimiter and token_tree arguments are preserved, so the
-                # presence and arity of the call still contributes to similarity.
-                # Note: tree-sitter-rust parses token_tree contents as structured
-                # nodes (string_literal, identifier, etc.), so the existing
-                # string-content and identifier rules already reach inside macro
-                # arguments.
-                name="Anonymize macro names",
-                languages=["rust"],
-                query="[(macro_invocation (identifier) @name) (macro_invocation (scoped_identifier) @name)]",
-                action=RuleAction.REMOVE,
-            ),
-            Rule(
-                # Lifetimes are borrow-checker annotations, not logic — omit non-static ones
-                # so that copy-pasted functions with renamed lifetime parameters ('a → 'b) are
-                # still detected as duplicates. 'static is preserved because it carries semantic
-                # content (permanent storage duration), unlike named lifetimes.
-                name="Omit non-static lifetimes",
-                languages=["rust"],
-                query="""((lifetime) @life (#not-eq? @life "'static"))""",
                 action=RuleAction.REMOVE,
             ),
             Rule(
@@ -104,6 +82,21 @@ class RustConfig(LanguageConfig):
 
     def get_loose_rules(self) -> list[Rule]:
         return [
+            Rule(
+                # Removes the macro path before `!` for both simple (`println!`)
+                # and scoped (`log::info!`) forms, so calls differing only in
+                # macro name (e.g. log level) normalize identically. The `!`
+                # delimiter and token_tree arguments are preserved, so the
+                # presence and arity of the call still contributes to similarity.
+                # Note: tree-sitter-rust parses token_tree contents as structured
+                # nodes (string_literal, identifier, etc.), so the existing
+                # string-content and identifier rules already reach inside macro
+                # arguments.
+                name="Anonymize macro names",
+                languages=["rust"],
+                query="[(macro_invocation (identifier) @name) (macro_invocation (scoped_identifier) @name)]",
+                action=RuleAction.REMOVE,
+            ),
             Rule(
                 name="Ignore string content",
                 languages=["rust"],

--- a/uv.lock
+++ b/uv.lock
@@ -982,7 +982,7 @@ wheels = [
 
 [[package]]
 name = "treepeat"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This PR adds support for the Rust language with both default and loose normalization rules.

Key highlights:
- **Generic Lifetimes:** Generic lifetimes (e.g., `'a`, `'b`) are treated as ignorable noise in both modes to focus on logical duplication, while `'static` is preserved because it carries significant semantic weight.
- **Anonymization Precison:** Type names in `impl` headers are intentionally *not* anonymized to prevent false-positives between unrelated types with similar method bodies.
- **Macros:** Macro names are anonymized in loose mode, while their structure is preserved. (TreeSitter already 'goes inside' macros)
- **Comprehensive Testing:** Includes a detailed fixture (`comprehensive.rs`) and unit tests for all rules using the `rule_tester` fixture.

Verified with `make test` and a sanity check on one of my local Rust projects.