### PR TITLE
Adding progress bar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Key flags:
 - `--diff`: Show side-by-side comparisons of similar blocks
 - `--format`: Output format - `console` (default) or `sarif` for CI integration
 - `--verbose`: Show additional run metrics, including per-stage timing when available
-- `--progress`: Show a progress bar while parsing files
+- `--progress`: Show progress bars for long-running pipeline stages
 
 ```bash
 # Find exact duplicates
@@ -48,7 +48,7 @@ treepeat detect --progress --verbose /path/to/codebase
 treepeat detect --format sarif -o results.sarif /path/to/codebase
 ```
 
-`--progress` is intended primarily as interactive CLI feedback. This shows parse-stage progress only and writes the tqdm progress bar to `stderr`, leaving normal command output on `stdout` or `--output`.
+`--progress` is intended primarily as interactive CLI feedback. The current implementation writes tqdm progress bars to `stderr`, leaving normal command output on `stdout` or `--output`.
 
 ### Other sub commands
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Key flags:
 - `--min-lines`: Minimum number of lines for a match (default: 5)
 - `--diff`: Show side-by-side comparisons of similar blocks
 - `--format`: Output format - `console` (default) or `sarif` for CI integration
+- `--verbose`: Show additional run metrics, including per-stage timing when available
+- `--progress`: Show a progress bar while parsing files
 
 ```bash
 # Find exact duplicates
@@ -39,9 +41,14 @@ treepeat detect --similarity 80 /path/to/codebase
 # Show diffs between similar blocks and use loose ruleset
 treepeat --ruleset loose detect --diff --min-lines 10 /path/to/codebase
 
+# Show parse progress and verbose stage timing
+treepeat detect --progress --verbose /path/to/codebase
+
 # Output results in SARIF format for CI tools
 treepeat detect --format sarif -o results.sarif /path/to/codebase
 ```
+
+`--progress` is intended primarily as interactive CLI feedback. This shows parse-stage progress only and writes the tqdm progress bar to `stderr`, leaving normal command output on `stdout` or `--output`.
 
 ### Other sub commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "python-magic>=0.4.27",
     "rich>=14.2.0",
     "sarif-pydantic>=0.6.2",
-    "tdqm>=0.0.1",
+    "tqdm>=4.0",
     "tree-sitter>=0.25.2",
     "tree-sitter-language-pack==0.13.0",
 ]

--- a/treepeat/cli/commands/detect.py
+++ b/treepeat/cli/commands/detect.py
@@ -406,36 +406,58 @@ _STAGE_LABELS: dict[str, tuple[str, str]] = {
 }
 
 
+def _display_verbose_node_metrics() -> None:
+    metrics = get_verbose_metrics()
+    if not metrics.used_node_types_by_language:
+        return
+
+    console.print("\nNodes analyzed by region:")
+    for language in sorted(metrics.used_node_types_by_language.keys()):
+        node_types = metrics.used_node_types_by_language[language]
+        excluded = metrics.excluded_node_types_by_language.get(language, set())
+        line = _format_language_node_types(language, node_types, excluded)
+        console.print(f"  {line}")
+
+
+def _build_stage_timings_table(elapsed_time: float) -> Table:
+    metrics = get_verbose_metrics()
+    table = Table(title="Stage timings", show_footer=True)
+    table.add_column("Stage", footer="total")
+    table.add_column("Items", justify="right", footer="")
+    table.add_column("Time (s)", justify="right", footer=f"[green]{elapsed_time:.2f}s[/green]")
+    table.add_column("%", justify="right", footer="")
+
+    for stage_key in ("parse", "extract", "shingle", "minhash", "lsh"):
+        if stage_key not in metrics.stage_timings:
+            continue
+        label, unit = _STAGE_LABELS[stage_key]
+        stage_time = metrics.stage_timings[stage_key]
+        stage_count = metrics.stage_counts.get(stage_key, 0)
+        stage_percent = (stage_time / elapsed_time * 100) if elapsed_time > 0 else 0.0
+        table.add_row(
+            label,
+            f"{stage_count:,} {unit}",
+            f"{stage_time:.2f}s",
+            f"{stage_percent:.0f}%",
+        )
+
+    return table
+
+
+def _display_verbose_timing_metrics(elapsed_time: float) -> None:
+    metrics = get_verbose_metrics()
+    if not metrics.stage_timings:
+        console.print(f"\nTotal time: [green]{elapsed_time:.2f}s[/green]")
+        return
+
+    console.print()
+    console.print(_build_stage_timings_table(elapsed_time))
+
+
 def _display_verbose_metrics(elapsed_time: float) -> None:
     """Display verbose metrics about the pipeline run."""
-    metrics = get_verbose_metrics()
-
-    if metrics.used_node_types_by_language:
-        console.print("\nNodes analyzed by region:")
-        for language in sorted(metrics.used_node_types_by_language.keys()):
-            node_types = metrics.used_node_types_by_language[language]
-            excluded = metrics.excluded_node_types_by_language.get(language, set())
-            line = _format_language_node_types(language, node_types, excluded)
-            console.print(f"  {line}")
-
-    if metrics.stage_timings:
-        table = Table(title="Stage timings", show_footer=True)
-        table.add_column("Stage", footer="total")
-        table.add_column("Items", justify="right", footer="")
-        table.add_column("Time (s)", justify="right", footer=f"[green]{elapsed_time:.2f}s[/green]")
-        table.add_column("%", justify="right", footer="")
-        for stage_key in ("parse", "extract", "shingle", "minhash", "lsh"):
-            if stage_key not in metrics.stage_timings:
-                continue
-            label, unit = _STAGE_LABELS[stage_key]
-            t = metrics.stage_timings[stage_key]
-            n = metrics.stage_counts.get(stage_key, 0)
-            pct = (t / elapsed_time * 100) if elapsed_time > 0 else 0.0
-            table.add_row(label, f"{n:,} {unit}", f"{t:.2f}s", f"{pct:.0f}%")
-        console.print()
-        console.print(table)
-    else:
-        console.print(f"\nTotal time: [green]{elapsed_time:.2f}s[/green]")
+    _display_verbose_node_metrics()
+    _display_verbose_timing_metrics(elapsed_time)
 
     console.print()
 

--- a/treepeat/cli/commands/detect.py
+++ b/treepeat/cli/commands/detect.py
@@ -162,17 +162,19 @@ def _write_output(text: str, output_path: Path | None) -> None:
         print(text)
 
 
-def _run_pipeline_with_ui(path: Path, output_format: str) -> SimilarityResult:
+def _run_pipeline_with_ui(path: Path, output_format: str, progress: bool = False) -> SimilarityResult:
     """Run the pipeline with appropriate UI feedback based on output format."""
     if output_format.lower() != "console":
-        return run_pipeline(path)
+        return run_pipeline(path, progress=progress)
 
     from treepeat.config import get_settings
     settings = get_settings()
     console.print(f"\nRuleset: [cyan]{settings.rules.ruleset}[/cyan]")
     console.print(f"Analyzing: [cyan]{path}[/cyan]\n")
+    if progress:
+        return run_pipeline(path, progress=True)
     with console.status("[bold green]Running pipeline..."):
-        return run_pipeline(path)
+        return run_pipeline(path, progress=False)
 
 
 def _group_signatures_by_file(
@@ -395,6 +397,15 @@ def _format_language_node_types(
     return f"{language}: {sorted_types}"
 
 
+_STAGE_LABELS: dict[str, tuple[str, str]] = {
+    "parse":   ("1/5 parse",   "files"),
+    "extract": ("2/5 extract", "regions"),
+    "shingle": ("3/5 shingle", "regions"),
+    "minhash": ("4/5 minhash", "sigs"),
+    "lsh":     ("5/5 lsh",     "groups"),
+}
+
+
 def _display_verbose_metrics(elapsed_time: float) -> None:
     """Display verbose metrics about the pipeline run."""
     metrics = get_verbose_metrics()
@@ -407,7 +418,26 @@ def _display_verbose_metrics(elapsed_time: float) -> None:
             line = _format_language_node_types(language, node_types, excluded)
             console.print(f"  {line}")
 
-    console.print(f"\nTotal time: [green]{elapsed_time:.2f}s[/green]\n")
+    if metrics.stage_timings:
+        table = Table(title="Stage timings", show_footer=True)
+        table.add_column("Stage", footer="total")
+        table.add_column("Items", justify="right", footer="")
+        table.add_column("Time (s)", justify="right", footer=f"[green]{elapsed_time:.2f}s[/green]")
+        table.add_column("%", justify="right", footer="")
+        for stage_key in ("parse", "extract", "shingle", "minhash", "lsh"):
+            if stage_key not in metrics.stage_timings:
+                continue
+            label, unit = _STAGE_LABELS[stage_key]
+            t = metrics.stage_timings[stage_key]
+            n = metrics.stage_counts.get(stage_key, 0)
+            pct = (t / elapsed_time * 100) if elapsed_time > 0 else 0.0
+            table.add_row(label, f"{n:,} {unit}", f"{t:.2f}s", f"{pct:.0f}%")
+        console.print()
+        console.print(table)
+    else:
+        console.print(f"\nTotal time: [green]{elapsed_time:.2f}s[/green]")
+
+    console.print()
 
 
 @click.command()
@@ -499,6 +529,13 @@ def _display_verbose_metrics(elapsed_time: float) -> None:
     default=False,
     help="Show verbose output including timing, ignored nodes, and used node types per language",
 )
+@click.option(
+    "--progress",
+    "-p",
+    is_flag=True,
+    default=False,
+    help="Show a progress bar while parsing files",
+)
 def detect(
     ctx: click.Context,
     path: Path,
@@ -512,6 +549,7 @@ def detect(
     fail: bool,
     ignore_node_types: str,
     verbose: bool,
+    progress: bool,
     add_regions: tuple[str, ...],
     exclude_regions: tuple[str, ...],
 ) -> None:
@@ -533,7 +571,7 @@ def detect(
     reset_verbose_metrics()
     start_time = time.time()
 
-    result = _run_pipeline_with_ui(path, output_format)
+    result = _run_pipeline_with_ui(path, output_format, progress=progress)
 
     elapsed_time = time.time() - start_time
 

--- a/treepeat/cli/commands/detect.py
+++ b/treepeat/cli/commands/detect.py
@@ -534,7 +534,7 @@ def _display_verbose_metrics(elapsed_time: float) -> None:
     "-p",
     is_flag=True,
     default=False,
-    help="Show a progress bar while parsing files",
+    help="Show progress bars for long-running pipeline stages",
 )
 def detect(
     ctx: click.Context,

--- a/treepeat/pipeline/lsh_stage.py
+++ b/treepeat/pipeline/lsh_stage.py
@@ -1,10 +1,18 @@
 """LSH stage for finding similar region pairs."""
 
 import logging
+import sys
 from pathlib import Path
 from typing import Hashable
 
 from datasketch import MinHashLSH  # type: ignore[import-untyped]
+
+try:
+    from tqdm import tqdm as _tqdm
+    _HAS_TQDM = True
+except ImportError:  # pragma: no cover
+    _tqdm = None  # type: ignore[assignment]
+    _HAS_TQDM = False
 
 from treepeat.models.shingle import ShingledRegion
 from treepeat.models.similarity import (
@@ -184,6 +192,7 @@ def _build_union_find_from_lsh(
     signatures: list[RegionSignature],
     lsh: MinHashLSH,
     similarity_percent: float,
+    progress: bool = False,
 ) -> tuple[UnionFind, dict[str, RegionSignature]]:
     """Build union-find structure from LSH queries."""
     uf = UnionFind()
@@ -193,7 +202,13 @@ def _build_union_find_from_lsh(
     # The actual verified similarity may be higher than the MinHash Jaccard similarity
     min_pair_similarity = 0.8 * similarity_percent
 
-    for sig in signatures:
+    iterable = (
+        _tqdm(signatures, desc="LSH", unit="signature", file=sys.stderr)
+        if progress and _HAS_TQDM
+        else signatures
+    )
+
+    for sig in iterable:
         # Use same key format as LSH index
         current_key = f"{sig.region.path}:{sig.region.region_name}:{sig.region.start_line}-{sig.region.end_line}"
         key_to_sig[current_key] = sig
@@ -270,10 +285,16 @@ def _collect_candidate_groups(
     signatures: list[RegionSignature],
     lsh: MinHashLSH,
     similarity_percent: float,
+    progress: bool = False,
 ) -> list[SimilarRegionGroup]:
     """Collect similar region groups from LSH queries."""
     # Build union-find structure
-    uf, key_to_sig = _build_union_find_from_lsh(signatures, lsh, similarity_percent)
+    uf, key_to_sig = _build_union_find_from_lsh(
+        signatures,
+        lsh,
+        similarity_percent,
+        progress=progress,
+    )
 
     # Extract groups from union-find
     groups_dict = uf.get_groups()
@@ -293,7 +314,7 @@ def _collect_candidate_groups(
 
 
 def find_similar_groups(
-    signatures: list[RegionSignature], similarity_percent: float
+    signatures: list[RegionSignature], similarity_percent: float, progress: bool = False
 ) -> list[SimilarRegionGroup]:
     """Find similar region groups using LSH."""
     if len(signatures) < 2:
@@ -307,7 +328,7 @@ def find_similar_groups(
     )
 
     lsh = _create_lsh_index(signatures, similarity_percent)
-    groups = _collect_candidate_groups(signatures, lsh, similarity_percent)
+    groups = _collect_candidate_groups(signatures, lsh, similarity_percent, progress=progress)
 
     groups.sort(key=lambda g: g.similarity, reverse=True)
     logger.info(
@@ -322,12 +343,17 @@ def _verify_and_filter_groups(
     candidate_groups: list[SimilarRegionGroup],
     shingled_regions: list[ShingledRegion],
     similarity_percent: float,
+    progress: bool = False,
 ) -> list[SimilarRegionGroup]:
     """Verify candidate groups and filter by minimum similarity similarity_percent."""
     from treepeat.pipeline.verification import verify_similar_groups
 
     logger.info("Verifying %d candidate group(s)", len(candidate_groups))
-    verified_groups = verify_similar_groups(candidate_groups, shingled_regions)
+    verified_groups = verify_similar_groups(
+        candidate_groups,
+        shingled_regions,
+        progress=progress,
+    )
 
     # Filter groups that fall below minimum similarity after verification
     similar_groups = [g for g in verified_groups if g.similarity >= similarity_percent]
@@ -398,6 +424,7 @@ def detect_similarity(
     similarity_percent: float,
     shingled_regions: list[ShingledRegion],
     min_lines: int = 5,
+    progress: bool = False,
 ) -> SimilarityResult:
     """Detect similar regions using LSH."""
     filtered_signatures, filtered_shingled = _filter_by_min_lines(
@@ -414,7 +441,11 @@ def detect_similarity(
     if not filtered_signatures:
         return SimilarityResult(signatures=[], similar_groups=[])
 
-    candidate_groups = find_similar_groups(filtered_signatures, similarity_percent)
+    candidate_groups = find_similar_groups(
+        filtered_signatures,
+        similarity_percent,
+        progress=progress,
+    )
 
     if not candidate_groups:
         return SimilarityResult(
@@ -423,7 +454,10 @@ def detect_similarity(
         )
 
     similar_groups = _verify_and_filter_groups(
-        candidate_groups, filtered_shingled, similarity_percent
+        candidate_groups,
+        filtered_shingled,
+        similarity_percent,
+        progress=progress,
     )
 
     return SimilarityResult(

--- a/treepeat/pipeline/lsh_stage.py
+++ b/treepeat/pipeline/lsh_stage.py
@@ -4,9 +4,9 @@ import logging
 import sys
 from pathlib import Path
 from typing import Hashable
-from typing import Any
 
 from datasketch import MinHashLSH  # type: ignore[import-untyped]
+from tqdm import tqdm  # type: ignore[import-untyped]
 
 from treepeat.models.shingle import ShingledRegion
 from treepeat.models.similarity import (
@@ -15,15 +15,6 @@ from treepeat.models.similarity import (
     SimilarRegionGroup,
     SimilarityResult,
 )
-
-try:
-    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
-    _HAS_TQDM = True
-except ImportError:  # pragma: no cover
-    _loaded_tqdm = None
-    _HAS_TQDM = False
-
-_tqdm: Any = _loaded_tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -206,8 +197,8 @@ def _build_union_find_from_lsh(
     min_pair_similarity = 0.8 * similarity_percent
 
     iterable = (
-        _tqdm(signatures, desc="LSH", unit="signature", file=sys.stderr)
-        if progress and _HAS_TQDM
+        tqdm(signatures, desc="LSH", unit="signature", file=sys.stderr)
+        if progress
         else signatures
     )
 

--- a/treepeat/pipeline/lsh_stage.py
+++ b/treepeat/pipeline/lsh_stage.py
@@ -8,6 +8,14 @@ from typing import Any
 
 from datasketch import MinHashLSH  # type: ignore[import-untyped]
 
+from treepeat.models.shingle import ShingledRegion
+from treepeat.models.similarity import (
+    Region,
+    RegionSignature,
+    SimilarRegionGroup,
+    SimilarityResult,
+)
+
 try:
     from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
     _HAS_TQDM = True
@@ -16,14 +24,6 @@ except ImportError:  # pragma: no cover
     _HAS_TQDM = False
 
 _tqdm: Any = _loaded_tqdm
-
-from treepeat.models.shingle import ShingledRegion
-from treepeat.models.similarity import (
-    Region,
-    RegionSignature,
-    SimilarRegionGroup,
-    SimilarityResult,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/treepeat/pipeline/lsh_stage.py
+++ b/treepeat/pipeline/lsh_stage.py
@@ -4,15 +4,18 @@ import logging
 import sys
 from pathlib import Path
 from typing import Hashable
+from typing import Any
 
 from datasketch import MinHashLSH  # type: ignore[import-untyped]
 
 try:
-    from tqdm import tqdm as _tqdm
+    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
     _HAS_TQDM = True
 except ImportError:  # pragma: no cover
-    _tqdm = None  # type: ignore[assignment]
+    _loaded_tqdm = None
     _HAS_TQDM = False
+
+_tqdm: Any = _loaded_tqdm
 
 from treepeat.models.shingle import ShingledRegion
 from treepeat.models.similarity import (

--- a/treepeat/pipeline/minhash_stage.py
+++ b/treepeat/pipeline/minhash_stage.py
@@ -6,6 +6,9 @@ from typing import Any
 
 from datasketch import MinHash  # type: ignore[import-untyped]
 
+from treepeat.models.shingle import ShingledRegion
+from treepeat.models.similarity import RegionSignature
+
 try:
     from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
     _HAS_TQDM = True
@@ -14,9 +17,6 @@ except ImportError:  # pragma: no cover
     _HAS_TQDM = False
 
 _tqdm: Any = _loaded_tqdm
-
-from treepeat.models.shingle import ShingledRegion
-from treepeat.models.similarity import RegionSignature
 
 logger = logging.getLogger(__name__)
 

--- a/treepeat/pipeline/minhash_stage.py
+++ b/treepeat/pipeline/minhash_stage.py
@@ -2,15 +2,18 @@
 
 import logging
 import sys
+from typing import Any
 
 from datasketch import MinHash  # type: ignore[import-untyped]
 
 try:
-    from tqdm import tqdm as _tqdm
+    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
     _HAS_TQDM = True
 except ImportError:  # pragma: no cover
-    _tqdm = None  # type: ignore[assignment]
+    _loaded_tqdm = None
     _HAS_TQDM = False
+
+_tqdm: Any = _loaded_tqdm
 
 from treepeat.models.shingle import ShingledRegion
 from treepeat.models.similarity import RegionSignature

--- a/treepeat/pipeline/minhash_stage.py
+++ b/treepeat/pipeline/minhash_stage.py
@@ -1,8 +1,16 @@
 """MinHash stage for similarity detection."""
 
 import logging
+import sys
 
 from datasketch import MinHash  # type: ignore[import-untyped]
+
+try:
+    from tqdm import tqdm as _tqdm
+    _HAS_TQDM = True
+except ImportError:  # pragma: no cover
+    _tqdm = None  # type: ignore[assignment]
+    _HAS_TQDM = False
 
 from treepeat.models.shingle import ShingledRegion
 from treepeat.models.similarity import RegionSignature
@@ -24,6 +32,7 @@ def create_minhash_signature(
 def compute_region_signatures(
     shingled_regions: list[ShingledRegion],
     num_perm: int = 128,
+    progress: bool = False,
 ) -> list[RegionSignature]:
     """Compute MinHash signatures for all shingled regions. """
     logger.info(
@@ -33,7 +42,13 @@ def compute_region_signatures(
     )
 
     signatures = []
-    for shingled_region in shingled_regions:
+    iterable = (
+        _tqdm(shingled_regions, desc="MinHash", unit="region", file=sys.stderr)
+        if progress and _HAS_TQDM
+        else shingled_regions
+    )
+
+    for shingled_region in iterable:
         try:
             # Get shingle contents as strings for MinHash
             shingle_contents = shingled_region.shingles.get_contents()

--- a/treepeat/pipeline/minhash_stage.py
+++ b/treepeat/pipeline/minhash_stage.py
@@ -2,21 +2,12 @@
 
 import logging
 import sys
-from typing import Any
 
 from datasketch import MinHash  # type: ignore[import-untyped]
+from tqdm import tqdm  # type: ignore[import-untyped]
 
 from treepeat.models.shingle import ShingledRegion
 from treepeat.models.similarity import RegionSignature
-
-try:
-    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
-    _HAS_TQDM = True
-except ImportError:  # pragma: no cover
-    _loaded_tqdm = None
-    _HAS_TQDM = False
-
-_tqdm: Any = _loaded_tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +37,8 @@ def compute_region_signatures(
 
     signatures = []
     iterable = (
-        _tqdm(shingled_regions, desc="MinHash", unit="region", file=sys.stderr)
-        if progress and _HAS_TQDM
+        tqdm(shingled_regions, desc="MinHash", unit="region", file=sys.stderr)
+        if progress
         else shingled_regions
     )
 

--- a/treepeat/pipeline/parse.py
+++ b/treepeat/pipeline/parse.py
@@ -2,13 +2,16 @@ import logging
 import sys
 from fnmatch import fnmatch
 from pathlib import Path
+from typing import Any
 
 try:
-    from tqdm import tqdm as _tqdm
+    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
     _HAS_TQDM = True
 except ImportError:  # pragma: no cover
-    _tqdm = None  # type: ignore[assignment]
+    _loaded_tqdm = None
     _HAS_TQDM = False
+
+_tqdm: Any = _loaded_tqdm
 
 from tree_sitter_language_pack import get_parser, SupportedLanguage
 

--- a/treepeat/pipeline/parse.py
+++ b/treepeat/pipeline/parse.py
@@ -2,22 +2,13 @@ import logging
 import sys
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any
 
+from tqdm import tqdm  # type: ignore[import-untyped]
 from tree_sitter_language_pack import get_parser, SupportedLanguage
 
 from treepeat.config import get_settings
 from treepeat.models import ParsedFile, ParseResult
 from treepeat.pipeline.languages import LANGUAGE_EXTENSIONS
-
-try:
-    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
-    _HAS_TQDM = True
-except ImportError:  # pragma: no cover
-    _loaded_tqdm = None
-    _HAS_TQDM = False
-
-_tqdm: Any = _loaded_tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -295,8 +286,8 @@ def collect_source_files(target_path: Path) -> list[Path]:
 def parse_files(files: list[Path], result: ParseResult, progress: bool = False) -> None:
     """Parse a list of files and update the result."""
     iterable = (
-        _tqdm(files, desc="Parsing", unit="file", file=sys.stderr)
-        if progress and _HAS_TQDM
+        tqdm(files, desc="Parsing", unit="file", file=sys.stderr)
+        if progress
         else files
     )
     for file_path in iterable:

--- a/treepeat/pipeline/parse.py
+++ b/treepeat/pipeline/parse.py
@@ -4,6 +4,12 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
+from tree_sitter_language_pack import get_parser, SupportedLanguage
+
+from treepeat.config import get_settings
+from treepeat.models import ParsedFile, ParseResult
+from treepeat.pipeline.languages import LANGUAGE_EXTENSIONS
+
 try:
     from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
     _HAS_TQDM = True
@@ -12,12 +18,6 @@ except ImportError:  # pragma: no cover
     _HAS_TQDM = False
 
 _tqdm: Any = _loaded_tqdm
-
-from tree_sitter_language_pack import get_parser, SupportedLanguage
-
-from treepeat.config import get_settings
-from treepeat.models import ParsedFile, ParseResult
-from treepeat.pipeline.languages import LANGUAGE_EXTENSIONS
 
 logger = logging.getLogger(__name__)
 

--- a/treepeat/pipeline/parse.py
+++ b/treepeat/pipeline/parse.py
@@ -1,6 +1,14 @@
 import logging
+import sys
 from fnmatch import fnmatch
 from pathlib import Path
+
+try:
+    from tqdm import tqdm as _tqdm
+    _HAS_TQDM = True
+except ImportError:  # pragma: no cover
+    _tqdm = None  # type: ignore[assignment]
+    _HAS_TQDM = False
 
 from tree_sitter_language_pack import get_parser, SupportedLanguage
 
@@ -281,9 +289,14 @@ def collect_source_files(target_path: Path) -> list[Path]:
     return []
 
 
-def parse_files(files: list[Path], result: ParseResult) -> None:
+def parse_files(files: list[Path], result: ParseResult, progress: bool = False) -> None:
     """Parse a list of files and update the result."""
-    for file_path in files:
+    iterable = (
+        _tqdm(files, desc="Parsing", unit="file", file=sys.stderr)
+        if progress and _HAS_TQDM
+        else files
+    )
+    for file_path in iterable:
         try:
             parsed = parse_file(file_path)
             result.parsed_files.append(parsed)
@@ -291,7 +304,7 @@ def parse_files(files: list[Path], result: ParseResult) -> None:
             logger.warning(f"Failed to parse {file_path}: {e}")
 
 
-def parse_path(target_path: Path) -> ParseResult:
+def parse_path(target_path: Path, progress: bool = False) -> ParseResult:
     """Parse a file or directory of source files."""
     logger.info(f"Starting parse of: {target_path}")
 
@@ -302,7 +315,7 @@ def parse_path(target_path: Path) -> ParseResult:
         logger.warning(f"Path does not exist or contains no source files: {target_path}")
         return result
 
-    parse_files(files, result)
+    parse_files(files, result, progress=progress)
 
     logger.info(f"Parse complete: {result.success_count} succeeded")
 

--- a/treepeat/pipeline/pipeline.py
+++ b/treepeat/pipeline/pipeline.py
@@ -41,11 +41,12 @@ def _run_parse_stage(target_path: Path, progress: bool = False) -> ParseResult:
 def _run_extract_stage(
     parsed_files: list[ParsedFile],
     rule_engine: RuleEngine,
+    progress: bool = False,
 ) -> list[ExtractedRegion]:
     """Run region extraction stage."""
     logger.info("Stage 2/5: Extracting regions...")
     _t = time.monotonic()
-    extracted_regions = extract_all_regions(parsed_files, rule_engine)
+    extracted_regions = extract_all_regions(parsed_files, rule_engine, progress=progress)
     elapsed = time.monotonic() - _t
     record_stage_timing("extract", elapsed)
     record_stage_count("extract", len(extracted_regions))
@@ -106,6 +107,7 @@ def _run_shingle_stage(
     parsed_files: list[ParsedFile],
     rule_engine: RuleEngine,
     settings: PipelineSettings,
+    progress: bool = False,
 ) -> list[ShingledRegion]:
     """Run shingling stage."""
     logger.info("Stage 3/5: Shingling regions (with rules)...")
@@ -115,6 +117,7 @@ def _run_shingle_stage(
         parsed_files,
         rule_engine=rule_engine,
         k=settings.shingle.k,
+        progress=progress,
     )
     elapsed = time.monotonic() - _t
     record_stage_timing("shingle", elapsed)
@@ -124,12 +127,16 @@ def _run_shingle_stage(
 
 
 def _run_minhash_stage(
-    shingled_regions: list[ShingledRegion], num_perm: int
+    shingled_regions: list[ShingledRegion], num_perm: int, progress: bool = False
 ) -> list[RegionSignature]:
     """Run MinHash signature computation stage."""
     logger.info("Stage 4/5: Computing MinHash signatures...")
     _t = time.monotonic()
-    signatures = compute_region_signatures(shingled_regions, num_perm=num_perm)
+    signatures = compute_region_signatures(
+        shingled_regions,
+        num_perm=num_perm,
+        progress=progress,
+    )
     elapsed = time.monotonic() - _t
     record_stage_timing("minhash", elapsed)
     record_stage_count("minhash", len(signatures))
@@ -142,6 +149,7 @@ def _run_lsh_stage(
     shingled_regions: list[ShingledRegion],
     threshold: float,
     min_lines: int,
+    progress: bool = False,
 ) -> SimilarityResult:
     """Run LSH similarity detection stage."""
     logger.info("Stage 5/5: Finding similar pairs...")
@@ -151,6 +159,7 @@ def _run_lsh_stage(
         similarity_percent=threshold,
         shingled_regions=shingled_regions,
         min_lines=min_lines,
+        progress=progress,
     )
     elapsed = time.monotonic() - _t
     record_stage_timing("lsh", elapsed)
@@ -194,12 +203,13 @@ def _run_region_matching(
     parsed_files: list[ParsedFile],
     rule_engine: RuleEngine,
     settings: PipelineSettings,
+    progress: bool = False,
 ) -> tuple[list[SimilarRegionGroup], list[RegionSignature]]:
     """Run region matching for functions and classes."""
     logger.info("===== REGION MATCHING =====")
 
     # Extract regions
-    extracted_regions = _run_extract_stage(parsed_files, rule_engine)
+    extracted_regions = _run_extract_stage(parsed_files, rule_engine, progress=progress)
 
     # If no regions, skip region matching entirely
     if not extracted_regions:
@@ -213,16 +223,27 @@ def _run_region_matching(
         return [], []
 
     # Shingle regions
-    region_shingled = _run_shingle_stage(extracted_regions, parsed_files, rule_engine, settings)
+    region_shingled = _run_shingle_stage(
+        extracted_regions,
+        parsed_files,
+        rule_engine,
+        settings,
+        progress=progress,
+    )
 
     # MinHash region
-    region_signatures = _run_minhash_stage(region_shingled, settings.minhash.num_perm)
+    region_signatures = _run_minhash_stage(
+        region_shingled,
+        settings.minhash.num_perm,
+        progress=progress,
+    )
 
     region_result = _run_lsh_stage(
         region_signatures,
         region_shingled,
         settings.lsh.similarity_percent,
         settings.lsh.min_lines,
+        progress=progress,
     )
 
     # Filter by min_lines
@@ -274,7 +295,7 @@ def run_pipeline(target_path: str | Path, progress: bool = False) -> SimilarityR
 
     # Run Region Matching
     similar_groups, signatures = _run_region_matching(
-        parse_result.parsed_files, rule_engine, settings
+        parse_result.parsed_files, rule_engine, settings, progress=progress
     )
 
     # Create final result

--- a/treepeat/pipeline/pipeline.py
+++ b/treepeat/pipeline/pipeline.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from pathlib import Path
 
 from treepeat.config import PipelineSettings, get_settings
@@ -20,18 +21,20 @@ from treepeat.pipeline.region_extraction import (
 from treepeat.pipeline.rules.engine import RuleEngine
 from treepeat.pipeline.rules_factory import build_rule_engine
 from treepeat.pipeline.shingle import shingle_regions
+from treepeat.pipeline.verbose_metrics import record_stage_count, record_stage_timing
 
 logger = logging.getLogger(__name__)
 
 
-def _run_parse_stage(target_path: Path) -> ParseResult:
+def _run_parse_stage(target_path: Path, progress: bool = False) -> ParseResult:
     """Run parsing stage."""
     logger.info("Stage 1/5: Parsing...")
-    parse_result = parse_path(target_path)
-    logger.info(
-        "Parse complete: %d succeeded",
-        parse_result.success_count,
-    )
+    _t = time.monotonic()
+    parse_result = parse_path(target_path, progress=progress)
+    elapsed = time.monotonic() - _t
+    record_stage_timing("parse", elapsed)
+    record_stage_count("parse", parse_result.success_count)
+    logger.info("Parse complete: %d succeeded (%.1fs)", parse_result.success_count, elapsed)
     return parse_result
 
 
@@ -41,8 +44,15 @@ def _run_extract_stage(
 ) -> list[ExtractedRegion]:
     """Run region extraction stage."""
     logger.info("Stage 2/5: Extracting regions...")
+    _t = time.monotonic()
     extracted_regions = extract_all_regions(parsed_files, rule_engine)
-    logger.info("Extracted %d region(s) from %d file(s)", len(extracted_regions), len(parsed_files))
+    elapsed = time.monotonic() - _t
+    record_stage_timing("extract", elapsed)
+    record_stage_count("extract", len(extracted_regions))
+    logger.info(
+        "Extracted %d region(s) from %d file(s) (%.1fs)",
+        len(extracted_regions), len(parsed_files), elapsed,
+    )
     return extracted_regions
 
 
@@ -99,13 +109,17 @@ def _run_shingle_stage(
 ) -> list[ShingledRegion]:
     """Run shingling stage."""
     logger.info("Stage 3/5: Shingling regions (with rules)...")
+    _t = time.monotonic()
     shingled_regions = shingle_regions(
         extracted_regions,
         parsed_files,
         rule_engine=rule_engine,
         k=settings.shingle.k,
     )
-    logger.info("Shingling complete: %d region(s) shingled", len(shingled_regions))
+    elapsed = time.monotonic() - _t
+    record_stage_timing("shingle", elapsed)
+    record_stage_count("shingle", len(shingled_regions))
+    logger.info("Shingling complete: %d region(s) shingled (%.1fs)", len(shingled_regions), elapsed)
     return shingled_regions
 
 
@@ -114,8 +128,12 @@ def _run_minhash_stage(
 ) -> list[RegionSignature]:
     """Run MinHash signature computation stage."""
     logger.info("Stage 4/5: Computing MinHash signatures...")
+    _t = time.monotonic()
     signatures = compute_region_signatures(shingled_regions, num_perm=num_perm)
-    logger.info("Created %d signature(s)", len(signatures))
+    elapsed = time.monotonic() - _t
+    record_stage_timing("minhash", elapsed)
+    record_stage_count("minhash", len(signatures))
+    logger.info("Created %d signature(s) (%.1fs)", len(signatures), elapsed)
     return signatures
 
 
@@ -127,16 +145,21 @@ def _run_lsh_stage(
 ) -> SimilarityResult:
     """Run LSH similarity detection stage."""
     logger.info("Stage 5/5: Finding similar pairs...")
+    _t = time.monotonic()
     similarity_result = detect_similarity(
         signatures,
         similarity_percent=threshold,
         shingled_regions=shingled_regions,
         min_lines=min_lines,
     )
+    elapsed = time.monotonic() - _t
+    record_stage_timing("lsh", elapsed)
+    record_stage_count("lsh", len(similarity_result.similar_groups))
     logger.info(
-        "Similarity detection complete: found %d similar group(s) (%d self-similar)",
+        "Similarity detection complete: found %d similar group(s) (%d self-similar) (%.1fs)",
         len(similarity_result.similar_groups),
         similarity_result.self_similarity_count,
+        elapsed,
     )
     return similarity_result
 
@@ -233,7 +256,7 @@ def _run_region_matching(
     return region_filtered_groups, region_signatures
 
 
-def run_pipeline(target_path: str | Path) -> SimilarityResult:
+def run_pipeline(target_path: str | Path, progress: bool = False) -> SimilarityResult:
     """Run the similarity detection pipeline on a target path."""
     settings = get_settings()
     logger.info("Starting pipeline for: %s (min_lines=%d)", target_path, settings.lsh.min_lines)
@@ -244,7 +267,7 @@ def run_pipeline(target_path: str | Path) -> SimilarityResult:
     rule_engine = build_rule_engine(settings)
 
     # Stage 1: Parse
-    parse_result = _run_parse_stage(target_path)
+    parse_result = _run_parse_stage(target_path, progress=progress)
     if parse_result.success_count == 0:
         logger.warning("No files successfully parsed, returning empty result")
         return SimilarityResult()

--- a/treepeat/pipeline/region_extraction.py
+++ b/treepeat/pipeline/region_extraction.py
@@ -4,16 +4,19 @@ import logging
 import sys
 from collections import Counter
 from dataclasses import dataclass
+from typing import Any
 
 from pydantic import BaseModel, Field
 from tree_sitter import Node
 
 try:
-    from tqdm import tqdm as _tqdm
+    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
     _HAS_TQDM = True
 except ImportError:  # pragma: no cover
-    _tqdm = None  # type: ignore[assignment]
+    _loaded_tqdm = None
     _HAS_TQDM = False
+
+_tqdm: Any = _loaded_tqdm
 
 from treepeat.models.ast import ParsedFile
 from treepeat.models.similarity import Region

--- a/treepeat/pipeline/region_extraction.py
+++ b/treepeat/pipeline/region_extraction.py
@@ -9,6 +9,12 @@ from typing import Any
 from pydantic import BaseModel, Field
 from tree_sitter import Node
 
+from treepeat.models.ast import ParsedFile
+from treepeat.models.similarity import Region
+
+from treepeat.pipeline.rules.engine import RuleEngine
+from treepeat.pipeline.verbose_metrics import record_used_node_type
+
 try:
     from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
     _HAS_TQDM = True
@@ -17,12 +23,6 @@ except ImportError:  # pragma: no cover
     _HAS_TQDM = False
 
 _tqdm: Any = _loaded_tqdm
-
-from treepeat.models.ast import ParsedFile
-from treepeat.models.similarity import Region
-
-from treepeat.pipeline.rules.engine import RuleEngine
-from treepeat.pipeline.verbose_metrics import record_used_node_type
 
 logger = logging.getLogger(__name__)
 

--- a/treepeat/pipeline/region_extraction.py
+++ b/treepeat/pipeline/region_extraction.py
@@ -1,11 +1,19 @@
 """Extract regions (functions, classes, sections, etc) from parsed files."""
 
 import logging
+import sys
 from collections import Counter
 from dataclasses import dataclass
 
 from pydantic import BaseModel, Field
 from tree_sitter import Node
+
+try:
+    from tqdm import tqdm as _tqdm
+    _HAS_TQDM = True
+except ImportError:  # pragma: no cover
+    _tqdm = None  # type: ignore[assignment]
+    _HAS_TQDM = False
 
 from treepeat.models.ast import ParsedFile
 from treepeat.models.similarity import Region
@@ -225,6 +233,7 @@ def _log_region_type_statistics(regions: list[ExtractedRegion], method: str) -> 
 def extract_all_regions(
     parsed_files: list[ParsedFile],
     rule_engine: "RuleEngine",
+    progress: bool = False,
 ) -> list[ExtractedRegion]:
     """Extract regions from all parsed files using only explicit extraction rules.
     If no rules exist for a language, log warning and skip that file.
@@ -233,7 +242,13 @@ def extract_all_regions(
 
     all_regions: list[ExtractedRegion] = []
 
-    for parsed_file in parsed_files:
+    iterable = (
+        _tqdm(parsed_files, desc="Extracting", unit="file", file=sys.stderr)
+        if progress and _HAS_TQDM
+        else parsed_files
+    )
+
+    for parsed_file in iterable:
         try:
             # Get explicit regions from rules
             regions = extract_regions(parsed_file, rule_engine)

--- a/treepeat/pipeline/region_extraction.py
+++ b/treepeat/pipeline/region_extraction.py
@@ -4,9 +4,9 @@ import logging
 import sys
 from collections import Counter
 from dataclasses import dataclass
-from typing import Any
 
 from pydantic import BaseModel, Field
+from tqdm import tqdm  # type: ignore[import-untyped]
 from tree_sitter import Node
 
 from treepeat.models.ast import ParsedFile
@@ -14,15 +14,6 @@ from treepeat.models.similarity import Region
 
 from treepeat.pipeline.rules.engine import RuleEngine
 from treepeat.pipeline.verbose_metrics import record_used_node_type
-
-try:
-    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
-    _HAS_TQDM = True
-except ImportError:  # pragma: no cover
-    _loaded_tqdm = None
-    _HAS_TQDM = False
-
-_tqdm: Any = _loaded_tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -246,8 +237,8 @@ def extract_all_regions(
     all_regions: list[ExtractedRegion] = []
 
     iterable = (
-        _tqdm(parsed_files, desc="Extracting", unit="file", file=sys.stderr)
-        if progress and _HAS_TQDM
+        tqdm(parsed_files, desc="Extracting", unit="file", file=sys.stderr)
+        if progress
         else parsed_files
     )
 

--- a/treepeat/pipeline/shingle.py
+++ b/treepeat/pipeline/shingle.py
@@ -1,8 +1,16 @@
 import logging
+import sys
 from collections import deque
 from pathlib import Path
 
 from tree_sitter import Node
+
+try:
+    from tqdm import tqdm as _tqdm
+    _HAS_TQDM = True
+except ImportError:  # pragma: no cover
+    _tqdm = None  # type: ignore[assignment]
+    _HAS_TQDM = False
 
 from treepeat.models.ast import ParsedFile, ParseResult
 from treepeat.models.normalization import NodeRepresentation, SkipNode
@@ -251,6 +259,7 @@ def shingle_regions(
     parsed_files: list[ParsedFile],
     rule_engine: RuleEngine,
     k: int = 3,
+    progress: bool = False,
 ) -> list[ShingledRegion]:
     logger.info(
         "Shingling %d region(s) across %d file(s) with k=%d",
@@ -263,8 +272,13 @@ def shingle_regions(
     shingler = ASTShingler(rule_engine=rule_engine, k=k)
     shingled_regions = []
     filtered_count = 0
+    iterable = (
+        _tqdm(extracted_regions, desc="Shingling", unit="region", file=sys.stderr)
+        if progress and _HAS_TQDM
+        else extracted_regions
+    )
 
-    for extracted_region in extracted_regions:
+    for extracted_region in iterable:
         try:
             shingled_region = _shingle_single_region(extracted_region, path_to_source, shingler)
             if shingled_region is not None:

--- a/treepeat/pipeline/shingle.py
+++ b/treepeat/pipeline/shingle.py
@@ -2,15 +2,18 @@ import logging
 import sys
 from collections import deque
 from pathlib import Path
+from typing import Any
 
 from tree_sitter import Node
 
 try:
-    from tqdm import tqdm as _tqdm
+    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
     _HAS_TQDM = True
 except ImportError:  # pragma: no cover
-    _tqdm = None  # type: ignore[assignment]
+    _loaded_tqdm = None
     _HAS_TQDM = False
+
+_tqdm: Any = _loaded_tqdm
 
 from treepeat.models.ast import ParsedFile, ParseResult
 from treepeat.models.normalization import NodeRepresentation, SkipNode

--- a/treepeat/pipeline/shingle.py
+++ b/treepeat/pipeline/shingle.py
@@ -6,15 +6,6 @@ from typing import Any
 
 from tree_sitter import Node
 
-try:
-    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
-    _HAS_TQDM = True
-except ImportError:  # pragma: no cover
-    _loaded_tqdm = None
-    _HAS_TQDM = False
-
-_tqdm: Any = _loaded_tqdm
-
 from treepeat.models.ast import ParsedFile, ParseResult
 from treepeat.models.normalization import NodeRepresentation, SkipNode
 from treepeat.models.shingle import (
@@ -27,6 +18,15 @@ from treepeat.models.shingle import (
 from treepeat.pipeline.region_extraction import ExtractedRegion
 from treepeat.pipeline.rules.engine import RuleEngine
 from treepeat.pipeline.rules.models import SkipNodeException
+
+try:
+    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
+    _HAS_TQDM = True
+except ImportError:  # pragma: no cover
+    _loaded_tqdm = None
+    _HAS_TQDM = False
+
+_tqdm: Any = _loaded_tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -257,6 +257,37 @@ def _shingle_single_region(
     return shingler.shingle_region(extracted_region, source)
 
 
+def _get_region_shingling_iterable(
+    extracted_regions: list[ExtractedRegion],
+    progress: bool,
+) -> list[ExtractedRegion] | Any:
+    if progress and _HAS_TQDM:
+        return _tqdm(extracted_regions, desc="Shingling", unit="region", file=sys.stderr)
+    return extracted_regions
+
+
+def _append_shingled_region(
+    extracted_region: ExtractedRegion,
+    path_to_source: dict[Path, bytes],
+    shingler: ASTShingler,
+    shingled_regions: list[ShingledRegion],
+) -> int:
+    shingled_region = _shingle_single_region(extracted_region, path_to_source, shingler)
+    if shingled_region is None:
+        return 1
+    shingled_regions.append(shingled_region)
+    return 0
+
+
+def _log_region_shingling_error(extracted_region: ExtractedRegion, error: Exception) -> None:
+    logger.error(
+        "Failed to shingle region %s in %s: %s",
+        extracted_region.region.region_name,
+        extracted_region.region.path,
+        error,
+    )
+
+
 def shingle_regions(
     extracted_regions: list[ExtractedRegion],
     parsed_files: list[ParsedFile],
@@ -273,28 +304,20 @@ def shingle_regions(
 
     path_to_source = {pf.path: pf.source for pf in parsed_files}
     shingler = ASTShingler(rule_engine=rule_engine, k=k)
-    shingled_regions = []
+    shingled_regions: list[ShingledRegion] = []
     filtered_count = 0
-    iterable = (
-        _tqdm(extracted_regions, desc="Shingling", unit="region", file=sys.stderr)
-        if progress and _HAS_TQDM
-        else extracted_regions
-    )
+    iterable = _get_region_shingling_iterable(extracted_regions, progress)
 
     for extracted_region in iterable:
         try:
-            shingled_region = _shingle_single_region(extracted_region, path_to_source, shingler)
-            if shingled_region is not None:
-                shingled_regions.append(shingled_region)
-            else:
-                filtered_count += 1
-        except Exception as e:
-            logger.error(
-                "Failed to shingle region %s in %s: %s",
-                extracted_region.region.region_name,
-                extracted_region.region.path,
-                e,
+            filtered_count += _append_shingled_region(
+                extracted_region,
+                path_to_source,
+                shingler,
+                shingled_regions,
             )
+        except Exception as e:
+            _log_region_shingling_error(extracted_region, e)
 
     logger.info(
         "Shingling complete: %d region(s) shingled, %d filtered",

--- a/treepeat/pipeline/shingle.py
+++ b/treepeat/pipeline/shingle.py
@@ -2,8 +2,9 @@ import logging
 import sys
 from collections import deque
 from pathlib import Path
-from typing import Any
+from typing import Iterable, cast
 
+from tqdm import tqdm  # type: ignore[import-untyped]
 from tree_sitter import Node
 
 from treepeat.models.ast import ParsedFile, ParseResult
@@ -18,15 +19,6 @@ from treepeat.models.shingle import (
 from treepeat.pipeline.region_extraction import ExtractedRegion
 from treepeat.pipeline.rules.engine import RuleEngine
 from treepeat.pipeline.rules.models import SkipNodeException
-
-try:
-    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
-    _HAS_TQDM = True
-except ImportError:  # pragma: no cover
-    _loaded_tqdm = None
-    _HAS_TQDM = False
-
-_tqdm: Any = _loaded_tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -260,9 +252,12 @@ def _shingle_single_region(
 def _get_region_shingling_iterable(
     extracted_regions: list[ExtractedRegion],
     progress: bool,
-) -> list[ExtractedRegion] | Any:
-    if progress and _HAS_TQDM:
-        return _tqdm(extracted_regions, desc="Shingling", unit="region", file=sys.stderr)
+) -> Iterable[ExtractedRegion]:
+    if progress:
+        return cast(
+            Iterable[ExtractedRegion],
+            tqdm(extracted_regions, desc="Shingling", unit="region", file=sys.stderr),
+        )
     return extracted_regions
 
 

--- a/treepeat/pipeline/verbose_metrics.py
+++ b/treepeat/pipeline/verbose_metrics.py
@@ -9,6 +9,8 @@ class VerboseMetrics:
 
     excluded_node_types_by_language: dict[str, set[str]] = field(default_factory=dict)
     used_node_types_by_language: dict[str, set[str]] = field(default_factory=dict)
+    stage_timings: dict[str, float] = field(default_factory=dict)
+    stage_counts: dict[str, int] = field(default_factory=dict)
 
 
 # Global metrics instance
@@ -38,3 +40,13 @@ def record_used_node_type(language: str, node_type: str) -> None:
     if language not in _metrics.used_node_types_by_language:
         _metrics.used_node_types_by_language[language] = set()
     _metrics.used_node_types_by_language[language].add(node_type)
+
+
+def record_stage_timing(stage: str, elapsed_s: float) -> None:
+    """Record wall-clock time for a pipeline stage."""
+    _metrics.stage_timings[stage] = elapsed_s
+
+
+def record_stage_count(stage: str, count: int) -> None:
+    """Record item count produced by a pipeline stage."""
+    _metrics.stage_counts[stage] = count

--- a/treepeat/pipeline/verification.py
+++ b/treepeat/pipeline/verification.py
@@ -1,16 +1,18 @@
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from treepeat.models.shingle import ShingledRegion
 
 try:
-    from tqdm import tqdm as _tqdm
+    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
     _HAS_TQDM = True
 except ImportError:  # pragma: no cover
-    _tqdm = None  # type: ignore[assignment]
+    _loaded_tqdm = None
     _HAS_TQDM = False
+
+_tqdm: Any = _loaded_tqdm
 
 if TYPE_CHECKING:
     from treepeat.models.similarity import Region, SimilarRegionGroup

--- a/treepeat/pipeline/verification.py
+++ b/treepeat/pipeline/verification.py
@@ -1,22 +1,13 @@
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
+from tqdm import tqdm  # type: ignore[import-untyped]
 from treepeat.models.shingle import ShingledRegion
 
 if TYPE_CHECKING:
     from treepeat.models.similarity import Region, SimilarRegionGroup
-
-try:
-    from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
-    _HAS_TQDM = True
-except ImportError:  # pragma: no cover
-    _loaded_tqdm = None
-    _HAS_TQDM = False
-
-_tqdm: Any = _loaded_tqdm
-
 
 logger = logging.getLogger(__name__)
 
@@ -204,8 +195,8 @@ def verify_similar_groups(
     verified_groups = []
 
     iterable = (
-        _tqdm(groups, desc="Verifying", unit="group", file=sys.stderr)
-        if progress and _HAS_TQDM
+        tqdm(groups, desc="Verifying", unit="group", file=sys.stderr)
+        if progress
         else groups
     )
 

--- a/treepeat/pipeline/verification.py
+++ b/treepeat/pipeline/verification.py
@@ -1,8 +1,16 @@
 import logging
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from treepeat.models.shingle import ShingledRegion
+
+try:
+    from tqdm import tqdm as _tqdm
+    _HAS_TQDM = True
+except ImportError:  # pragma: no cover
+    _tqdm = None  # type: ignore[assignment]
+    _HAS_TQDM = False
 
 if TYPE_CHECKING:
     from treepeat.models.similarity import Region, SimilarRegionGroup
@@ -181,6 +189,7 @@ def _verify_group_pairwise_similarity(
 def verify_similar_groups(
     groups: list["SimilarRegionGroup"],
     shingled_regions: list[ShingledRegion],
+    progress: bool = False,
 ) -> list["SimilarRegionGroup"]:
     """Verify candidate groups using order-sensitive similarity.
 
@@ -192,7 +201,13 @@ def verify_similar_groups(
     region_lookup = _build_region_lookup(shingled_regions)
     verified_groups = []
 
-    for group in groups:
+    iterable = (
+        _tqdm(groups, desc="Verifying", unit="group", file=sys.stderr)
+        if progress and _HAS_TQDM
+        else groups
+    )
+
+    for group in iterable:
         # Recalculate group similarity using order-sensitive verification
         verified_similarity = _verify_group_pairwise_similarity(
             group.regions, region_lookup

--- a/treepeat/pipeline/verification.py
+++ b/treepeat/pipeline/verification.py
@@ -5,6 +5,9 @@ from typing import TYPE_CHECKING, Any
 
 from treepeat.models.shingle import ShingledRegion
 
+if TYPE_CHECKING:
+    from treepeat.models.similarity import Region, SimilarRegionGroup
+
 try:
     from tqdm import tqdm as _loaded_tqdm  # type: ignore[import-untyped]
     _HAS_TQDM = True
@@ -13,9 +16,6 @@ except ImportError:  # pragma: no cover
     _HAS_TQDM = False
 
 _tqdm: Any = _loaded_tqdm
-
-if TYPE_CHECKING:
-    from treepeat.models.similarity import Region, SimilarRegionGroup
 
 
 logger = logging.getLogger(__name__)

--- a/uv.lock
+++ b/uv.lock
@@ -809,15 +809,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tdqm"
-version = "0.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/38/58c9e22b95e98666fe29f35e217ab6126a03798dadf3f4f8f3e5f898510b/tdqm-0.0.1.tar.gz", hash = "sha256:f050004a76b1d22f70b78209b48781353c82440215b6ba7d22b1f499b05a0101", size = 1388, upload-time = "2020-08-19T20:16:22.191Z" }
-
-[[package]]
 name = "tomli"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -982,7 +973,7 @@ wheels = [
 
 [[package]]
 name = "treepeat"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -993,7 +984,7 @@ dependencies = [
     { name = "python-magic" },
     { name = "rich" },
     { name = "sarif-pydantic" },
-    { name = "tdqm" },
+    { name = "tqdm" },
     { name = "tree-sitter" },
     { name = "tree-sitter-language-pack" },
 ]
@@ -1018,7 +1009,7 @@ requires-dist = [
     { name = "python-magic", specifier = ">=0.4.27" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "sarif-pydantic", specifier = ">=0.6.2" },
-    { name = "tdqm", specifier = ">=0.0.1" },
+    { name = "tqdm", specifier = ">=4.0" },
     { name = "tree-sitter", specifier = ">=0.25.2" },
     { name = "tree-sitter-language-pack", specifier = "==0.13.0" },
 ]


### PR DESCRIPTION
My initial thought was that parsing would be the most interesting place to enable a progress bar (first commit). But playing with that a bit quickly showed that better visibility would help across-the-board. So all 5 phases now show a progress bar when the --progress flag is present. This uses standard tqdm on stderr. Second commit extends it to all 5 phases.

Tested with some really large repos. Identified high memory consumption/swap usage on phase 3 -- this may be worth following up on separately. 