### PR TITLE
Add performance characterization harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ __pycache__/
 .pytest_cache/
 .aider*
 sample-data/
+
+# Performance harness output
+tools/perf/output/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ make setup
 make test
 ```
 
+Performance harness for benchmarking real repositories: `tools/perf/harness.py` ([docs](docs/perf-harness.md)).
+
 ## ADRs
 
 Architecture Decision Records live in docs/adr.

--- a/docs/perf-harness.md
+++ b/docs/perf-harness.md
@@ -101,7 +101,10 @@ in `ignore_dirs`.
 
 **Per-stage counts** (parsed from INFO log output):
 `parse_succeeded`, `regions_extracted`, `regions_to_shingle`,
-`regions_shingled`, `signatures`, `groups_found`.
+`regions_shingled`, `signatures`, `groups_found`, `candidate_pairs`.
+`candidate_pairs` is the total number of region pairs entering LCS verification
+(sum of C(|group|, 2) over all candidate groups); it distinguishes
+false-candidate-explosion (large value relative to N) from raw-scale slowness.
 
 **Per-stage elapsed times** (when treepeat emits inline `(Xs)` suffixes):
 `t_parse_s`, `t_extract_s`, `t_shingle_s`, `t_minhash_s`, `t_lsh_s`.

--- a/docs/perf-harness.md
+++ b/docs/perf-harness.md
@@ -26,7 +26,7 @@ Output lands in `tools/perf/output/` (gitignored):
 
 | File | Contents |
 |------|----------|
-| `run_<ts>.log` | Full stdout+stderr for each repo, plus a tab-separated summary |
+| `run_<ts>.log` | Full stdout+stderr for each repo |
 | `run_<ts>.csv` | One row per repo — import into a spreadsheet for curve fitting |
 | `run_<ts>.json` | Structured results, machine-readable, includes RSS time series |
 
@@ -87,9 +87,9 @@ without removing it.
 
 ## What is measured
 
-**File census** : source file count and total line
-count, excluding standard skip dirs (`node_modules`, `__pycache__`, `build`,
-etc.) and any dirs listed in `extra_args --ignore-dirs`.
+**File census**: source file count and total line count, excluding standard
+skip dirs (`node_modules`, `__pycache__`, `build`, etc.) and any dirs listed
+in `ignore_dirs`.
 
 **Timing**: wall-clock elapsed time for the full treepeat invocation.
 

--- a/docs/perf-harness.md
+++ b/docs/perf-harness.md
@@ -1,0 +1,146 @@
+# Performance Characterization Harness
+
+`tools/perf/harness.py` measures treepeat's time and memory usage across a
+range of real-world repos to establish the file-count / SLOC / clone-density
+vs. time+memory curve.  The primary goal is to guide optimization work and
+validate (or refute) the swapping hypothesis: that memory pressure becomes
+acute around 2,000–3,000 source files on a 32 GB machine.
+
+## Quick start
+
+```bash
+# 1. Clone repos (first time only)
+python tools/perf/harness.py --clone
+
+# 2. Run
+python tools/perf/harness.py
+
+# 3. Single repo
+python tools/perf/harness.py --repo requests
+
+# 4. File census only — no treepeat invocation
+python tools/perf/harness.py --dry-run
+```
+
+Output lands in `tools/perf/output/` (gitignored):
+
+| File | Contents |
+|------|----------|
+| `run_<ts>.log` | Full stdout+stderr for each repo, plus a tab-separated summary |
+| `run_<ts>.csv` | One row per repo — import into a spreadsheet for curve fitting |
+| `run_<ts>.json` | Structured results, machine-readable, includes RSS time series |
+
+## Config file
+
+The default config is `tools/perf/perf_repos.toml`.  Pass `--config PATH` to
+use a different file.
+
+```toml
+[defaults]
+clone_base = "~/.config/treepeat-dev"   # where repos are cloned
+
+[[repos]]
+name       = "requests"
+url        = "https://github.com/psf/requests"
+ref        = "v2.33.1"
+languages  = ["python"]                 # informational
+notes      = "Small baseline"
+
+[[repos]]
+name        = "django"
+url         = "https://github.com/django/django"
+ref         = "4.2"
+languages   = ["python"]
+ignore_dirs = ["docs"]       # excluded from file census and treepeat scan
+extra_args  = []             # passed directly to `treepeat detect`
+enabled     = true           # set false to skip without deleting
+```
+
+All repos listed in the config are run.  Set `enabled = false` to skip one
+without removing it.
+
+### Field reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Short identifier; used as the clone directory name |
+| `url` | for `--clone` | Git URL |
+| `ref` | no | Branch, tag, or commit to check out |
+| `path` | no | Absolute local path — skips `clone_base` entirely |
+| `clone_to` | no | Per-repo clone path override |
+| `languages` | no | Informational label(s), e.g. `["python"]` |
+| `ignore_dirs` | no | Directory names excluded from file census and converted to `--ignore **/dir/**` for treepeat |
+| `extra_args` | no | Extra flags passed directly to `treepeat detect` |
+| `enabled` | no | Default `true`; set `false` to skip |
+| `notes` | no | Free-form description |
+
+## CLI flags
+
+```
+--config PATH      TOML config file (default: tools/perf/perf_repos.toml)
+--repo NAME        Run only this repo
+--timeout S        Per-repo timeout in seconds (default: 1800)
+--dry-run          Count source files only; do not invoke treepeat
+--clone            Clone repos that are missing from disk
+--output-dir DIR   Output directory (default: tools/perf/output/)
+```
+
+## What is measured
+
+**File census** : source file count and total line
+count, excluding standard skip dirs (`node_modules`, `__pycache__`, `build`,
+etc.) and any dirs listed in `extra_args --ignore-dirs`.
+
+**Timing**: wall-clock elapsed time for the full treepeat invocation.
+
+**Memory** (two independent sources):
+- `/usr/bin/time -l` (macOS) / `-v` (Linux): authoritative peak RSS on clean
+  exit, plus hard page faults and swap counts — the key swapping indicators.
+- Background RSS poller: samples the treepeat process via `ps` every 15 s.
+  This is the only memory source when treepeat times out.
+
+**Per-stage counts** (parsed from INFO log output):
+`parse_succeeded`, `regions_extracted`, `regions_to_shingle`,
+`regions_shingled`, `signatures`, `groups_found`.
+
+**Per-stage elapsed times** (when treepeat emits inline `(Xs)` suffixes):
+`t_parse_s`, `t_extract_s`, `t_shingle_s`, `t_minhash_s`, `t_lsh_s`.
+
+**Clone count**: total SARIF results (cross-check against `groups_found`).
+
+## Platform notes
+
+| Platform | `/usr/bin/time` flag | `ps` poller | Status |
+|----------|----------------------|-------------|--------|
+| macOS | `-l` (bytes RSS) | yes | fully supported |
+| Linux (glibc, standard distros) | `-v` (kbytes RSS) | yes | fully supported |
+| Linux (Alpine / busybox containers) | not supported | yes | harness warns and falls back to polled RSS only; page-fault and swap counts unavailable |
+| Windows | not present | no | not supported (contributions welcome!) |
+
+The harness probes `/usr/bin/time <flag> true` once (via `lru_cache`) before
+the first run and logs a warning if the flag is unsupported.  All other
+metrics (stage counts, elapsed time, SARIF clone count, polled RSS) are
+unaffected.
+
+## Invocation
+
+The harness is a standalone script, not a pytest suite. Invoke it directly:
+
+```bash
+python tools/perf/harness.py --clone
+```
+
+## Wishlist
+
+Features that would improve instrumentation without requiring external tools:
+
+1. **Per-stage elapsed time to stderr** — emit `Stage N/5: <name> [elapsed Xs]`
+   so stage wall time is available regardless of output format.
+2. **`--verbose` with `-f sarif`** — verbose metrics currently only appear in
+   console mode; they should also go to stderr in sarif mode.
+3. **Peak RSS self-reporting** — emit `resource.getrusage(RUSAGE_SELF).ru_maxrss`
+   to stderr at pipeline end to avoid the `/usr/bin/time` wrapper requirement.
+4. **Structured PERF log line** — emit a single `WARNING`-level line with all
+   stage counts so it is always visible without `--verbose`.
+5. **`--min-regions`** — skip repos with fewer than N extracted regions for
+   quick early-exit on effectively-empty scans.

--- a/docs/perf-harness.md
+++ b/docs/perf-harness.md
@@ -9,17 +9,20 @@ acute around 2,000–3,000 source files on a 32 GB machine.
 ## Quick start
 
 ```bash
-# 1. Clone repos (first time only)
-python tools/perf/harness.py --clone
+# 1. Set up the project environment
+make setup
 
-# 2. Run
-python tools/perf/harness.py
+# 2. Clone repos and run (first time only)
+uv run python tools/perf/harness.py --clone
 
-# 3. Single repo
-python tools/perf/harness.py --repo requests
+# 3. Run again without cloning
+uv run python tools/perf/harness.py
 
-# 4. File census only — no treepeat invocation
-python tools/perf/harness.py --dry-run
+# 4. Single repo
+uv run python tools/perf/harness.py --repo requests
+
+# 5. File census only — no treepeat invocation
+uv run python tools/perf/harness.py --dry-run
 ```
 
 Output lands in `tools/perf/output/` (gitignored):
@@ -85,6 +88,16 @@ without removing it.
 --output-dir DIR   Output directory (default: tools/perf/output/)
 ```
 
+## Console summary
+
+The live per-repo summary is intentionally compact.
+
+- `Shngs` = `regions_shingled`
+- `Shng` = `t_shingle_s`
+- `Mem` = `max(peak_rss_mb, peak_polled_rss_mb)`
+
+For full per-stage timings and raw metrics, use the CSV/JSON outputs.
+
 ## What is measured
 
 **File census**: source file count and total line count, excluding standard
@@ -96,7 +109,7 @@ in `ignore_dirs`.
 **Memory** (two independent sources):
 - `/usr/bin/time -l` (macOS) / `-v` (Linux): authoritative peak RSS on clean
   exit, plus hard page faults and swap counts — the key swapping indicators.
-- Background RSS poller: samples the treepeat process via `ps` every 15 s.
+- Background RSS poller: samples the treepeat process via `psutil` every 15 s.
   This is the only memory source when treepeat times out.
 
 **Per-stage counts** (parsed from INFO log output):
@@ -130,7 +143,8 @@ unaffected.
 The harness is a standalone script, not a pytest suite. Invoke it directly:
 
 ```bash
-python tools/perf/harness.py --clone
+make setup
+uv run python tools/perf/harness.py --clone
 ```
 
 ## Wishlist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest-cov>=6",
     "ruff>=0.5",
     "mypy>=1.10",
+    "psutil>=7.0.0",
     "pre-commit>=3.7",
     "radon>=6.0.1",
 ]

--- a/tools/perf/harness.py
+++ b/tools/perf/harness.py
@@ -28,14 +28,14 @@ Config file format (TOML):
     notes      = "Small, clean baseline"
 
     [[repos]]
-    name       = "django"
-    url        = "https://github.com/django/django"
-    ref        = "4.2"
-    languages  = ["python"]
-    extra_args = ["--ignore-dirs", "docs"]
+    name        = "django"
+    url         = "https://github.com/django/django"
+    ref         = "4.2"
+    languages   = ["python"]
+    ignore_dirs = ["docs"]
 
 Output (tools/perf/output/ under the treepeat repo root, or --output-dir):
-    run_<ts>.log    captured stdout+stderr for each repo, tab-separated summary
+    run_<ts>.log    captured stdout+stderr for each repo
     run_<ts>.csv    one row per repo — import into a spreadsheet for curve fitting
     run_<ts>.json   structured results (full, machine-readable)
 
@@ -183,8 +183,8 @@ class PerfResult:
     sarif_clones:      int   = 0
 
     # RSS time series: list of [elapsed_s, rss_mb] snapshots from background poller.
-    # Populated for all runs (completed and timed-out). Each entry is a 2-element list
-    # so it round-trips cleanly through JSON.
+    # Sampled every 15 s; runs shorter than the interval will have an empty list.
+    # Each entry is a 2-element list so it round-trips cleanly through JSON.
     rss_samples:       list  = field(default_factory=list)
 
 
@@ -279,19 +279,36 @@ def clone_repo(repo: RepoConfig, root: Path) -> bool:
     root.parent.mkdir(parents=True, exist_ok=True)
     _emit(f"   cloning {repo.url} → {root}")
 
+    # Decide clone strategy: --branch works for tags and branch names but not
+    # bare commit SHAs.  Detect a SHA (40 hex chars) and fall back to a full
+    # clone + checkout so arbitrary commits work.
+    ref = repo.ref
+    is_sha = ref is not None and len(ref) >= 7 and all(c in "0123456789abcdefABCDEF" for c in ref)
+
     try:
-        subprocess.run(
-            ["git", "clone", "--depth", "1",
-             *(["--branch", repo.ref] if repo.ref else []),
-             repo.url, str(root)],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            timeout=CLONE_TIMEOUT_S,
-        )
+        if is_sha:
+            # Full clone (no --depth) then checkout the commit
+            subprocess.run(
+                ["git", "clone", repo.url, str(root)],
+                check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                timeout=CLONE_TIMEOUT_S,
+            )
+            subprocess.run(
+                ["git", "-C", str(root), "checkout", ref],
+                check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                timeout=60,
+            )
+        else:
+            subprocess.run(
+                ["git", "clone", "--depth", "1",
+                 *(["--branch", ref] if ref else []),
+                 repo.url, str(root)],
+                check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                timeout=CLONE_TIMEOUT_S,
+            )
         return True
     except subprocess.TimeoutExpired:
-        _emit(f"   git clone timed out after {CLONE_TIMEOUT_S}s — partial clone left at {root}")
+        _emit(f"   git clone timed out after {CLONE_TIMEOUT_S}s — cleaning up {root}")
         shutil.rmtree(root, ignore_errors=True)
         return False
     except subprocess.CalledProcessError as exc:
@@ -472,15 +489,8 @@ def _poll_rss(
     """
     target_pid: int | None = None
 
-    while not stop.wait(interval_s):
-        if target_pid is None:
-            if use_wrapper:
-                target_pid = _find_treepeat_child_pid(wrapper_pid)
-            else:
-                target_pid = wrapper_pid
-
-        pid = target_pid if target_pid is not None else wrapper_pid
-
+    def _sample(pid: int) -> bool:
+        """Sample RSS for pid; return False if the process has exited."""
         try:
             rss_out = subprocess.check_output(
                 ["ps", "-p", str(pid), "-o", "rss="],
@@ -491,7 +501,30 @@ def _poll_rss(
                 rss_mb = int(rss_kb) / 1024
                 elapsed = time.monotonic() - t0
                 samples.append([elapsed, rss_mb])
+            return True
         except Exception:
+            return False
+
+    # Take an immediate sample so short runs (< interval_s) still get data.
+    # Give the process a moment to start before the first read.
+    stop.wait(1.0)
+    if not stop.is_set():
+        pid0 = (
+            _find_treepeat_child_pid(wrapper_pid) if use_wrapper else wrapper_pid
+        ) or wrapper_pid
+        _sample(pid0)
+        target_pid = pid0 if pid0 != wrapper_pid else None
+
+    while not stop.wait(interval_s):
+        if target_pid is None:
+            if use_wrapper:
+                target_pid = _find_treepeat_child_pid(wrapper_pid)
+            else:
+                target_pid = wrapper_pid
+
+        pid = target_pid if target_pid is not None else wrapper_pid
+
+        if not _sample(pid):
             break
 
 
@@ -816,7 +849,7 @@ def main() -> None:
         elif result.error:
             _emit(f"   ✗ error: {result.error}  ({result.elapsed_s:.1f}s)")
         elif result.timed_out:
-            rss_note = (f"  rss_peak={result.peak_rss_mb:.0f}MiB"
+            rss_note = (f"  rss_peak={result.peak_polled_rss_mb:.0f}MiB"
                         f" ({len(result.rss_samples)} samples)"
                         if result.rss_samples else "")
             _emit(f"   ✗ TIMEOUT after {result.elapsed_s:.0f}s{rss_note}")

--- a/tools/perf/harness.py
+++ b/tools/perf/harness.py
@@ -1,0 +1,848 @@
+"""tools/perf/harness.py — Treepeat performance characterization harness.
+
+Runs treepeat on repos defined in a TOML config file (default: perf_repos.toml
+in this directory).  Captures wall-clock time, peak RSS (/usr/bin/time -l),
+per-stage counts from INFO logs, and clone count from SARIF output.
+
+Goal: establish the file-count / SLOC / clone-density vs. time+memory curve
+to guide treepeat's optimization roadmap and validate the swapping hypothesis
+(suspected around 2000–3000 source files on a 32GB MacBook).
+
+Usage:
+    python tools/perf/harness.py
+    python tools/perf/harness.py --repo requests
+    python tools/perf/harness.py --timeout 600
+    python tools/perf/harness.py --dry-run
+    python tools/perf/harness.py --clone           # auto-clone missing repos
+    python tools/perf/harness.py --config my_repos.toml
+
+Config file format (TOML):
+    [defaults]
+    clone_base = "~/.config/treepeat-dev"   # where to clone repos
+
+    [[repos]]
+    name       = "requests"
+    url        = "https://github.com/psf/requests"
+    ref        = "v2.33.1"
+    languages  = ["python"]
+    notes      = "Small, clean baseline"
+
+    [[repos]]
+    name       = "django"
+    url        = "https://github.com/django/django"
+    ref        = "4.2"
+    languages  = ["python"]
+    extra_args = ["--ignore-dirs", "docs"]
+
+Output (tools/perf/output/ under the treepeat repo root, or --output-dir):
+    run_<ts>.log    captured stdout+stderr for each repo, tab-separated summary
+    run_<ts>.csv    one row per repo — import into a spreadsheet for curve fitting
+    run_<ts>.json   structured results (full, machine-readable)
+
+Wishlist for future treepeat improvements that would enhance perf instrumentation:
+  1. Per-stage elapsed time: emit "Stage N/5: <name> [elapsed Xs]" to stderr so
+     per-stage wall time is available independent of output format.
+  2. --verbose with -f sarif: currently verbose metrics go to stdout only in
+     console mode; should also work in sarif mode (output to stderr).
+  3. Peak RSS self-reporting: emit resource.getrusage(RUSAGE_SELF).ru_maxrss
+     to stderr at pipeline end — avoids /usr/bin/time wrapper requirement.
+  4. Region count per stage to stderr: parse_succeeded, regions_extracted,
+     shingled, signatures already logged at INFO; consider a structured
+     "PERF" log line at WARNING level so it's always visible.
+  5. --min-regions: option to skip repos with < N extracted regions to allow
+     quick early-exit on effectively-empty scans.
+"""
+
+import argparse
+import csv
+import functools
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import tomllib
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT  = Path(__file__).resolve().parents[2]
+VENV_BIN   = REPO_ROOT / ".venv" / "bin"
+
+DEFAULT_TIMEOUT_S  = 1800   # 30 minutes per repo
+DEFAULT_RULESET    = "default"
+DEFAULT_MIN_LINES  = 5
+DEFAULT_CLONE_BASE = "~/.config/treepeat-dev"
+
+_USR_BIN_TIME = "/usr/bin/time"
+
+
+@functools.lru_cache(maxsize=1)
+def _time_wrapper_ok() -> bool:
+    """Return True if /usr/bin/time supports the platform flag (-l/-v).
+
+    Probed once per process via lru_cache.  On minimal Linux systems
+    (Alpine, some containers) /usr/bin/time is busybox and does not support
+    -v; on those platforms the wrapper is disabled and only the polled RSS
+    is available.
+    """
+    flag = "-l" if sys.platform == "darwin" else "-v"
+    try:
+        r = subprocess.run(
+            [_USR_BIN_TIME, flag, "true"],
+            capture_output=True,
+            timeout=5,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+# Strip ANSI escape codes (Rich logging emits these)
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\(B")
+
+# Extensions treepeat can process
+_KNOWN_EXTS: frozenset[str] = frozenset({
+    ".py", ".pyw",
+    ".js", ".jsx", ".mjs", ".cjs",
+    ".ts", ".tsx",
+    ".java",
+    ".rs",
+    ".go",
+    ".c", ".h",
+    ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx",
+    ".rb",
+    ".cs",
+    ".kt", ".kts",
+    ".swift",
+})
+
+# Dirs to skip when counting source files
+_SKIP_DIRS: frozenset[str] = frozenset({
+    ".git", ".hg", ".svn",
+    "node_modules", ".pnp",
+    "target", "build", "dist", ".gradle", ".maven",
+    ".venv", "venv", "__pycache__", ".pytest_cache", ".tox",
+    "coverage_html_report", ".next", ".nuxt", ".cache",
+    ".pio", "log", "archive",
+})
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PerfResult:
+    name:              str
+    root:              str
+    languages:         list
+
+    # Pre-run file census
+    src_files:         int   = 0    # source files with known extensions
+    src_lines:         int   = 0    # total source lines
+
+    # Outcome
+    timed_out:         bool  = False
+    error:             str   = ""
+
+    # Timing (seconds)
+    elapsed_s:         float = 0.0
+
+    # Memory — two independent sources
+    peak_rss_mb:        float = 0.0  # from /usr/bin/time -l (authoritative on clean exit)
+    peak_polled_rss_mb: float = 0.0  # max of background poller samples (only source on timeout)
+    page_faults:        int   = 0    # hard page faults (I/O reads) — key swapping indicator
+    swaps:              int   = 0    # actual swap-out operations
+
+    # Stage counts (from INFO log lines on stdout)
+    parse_succeeded:   int   = 0    # "Parse complete: N succeeded"
+    regions_extracted: int   = 0    # "Extracted N total region(s)"
+    regions_to_shingle:int   = 0    # "Shingling N region(s) across" (after min_lines filter)
+    regions_shingled:  int   = 0    # "Shingling complete: N region(s)"
+    signatures:        int   = 0    # "Created N signature(s)"
+    groups_found:      int   = 0    # "found N similar group(s)"
+
+    # Per-stage elapsed times (seconds) parsed from inline "(Xs)" suffixes
+    t_parse_s:         float = 0.0  # parse stage
+    t_extract_s:       float = 0.0  # region extraction
+    t_shingle_s:       float = 0.0  # shingling
+    t_minhash_s:       float = 0.0  # minhash
+    t_lsh_s:           float = 0.0  # LSH similarity search
+
+    # Clone count from SARIF (cross-check vs groups_found)
+    sarif_clones:      int   = 0
+
+    # RSS time series: list of [elapsed_s, rss_mb] snapshots from background poller.
+    # Populated for all runs (completed and timed-out). Each entry is a 2-element list
+    # so it round-trips cleanly through JSON.
+    rss_samples:       list  = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Defaults:
+    clone_base: str = DEFAULT_CLONE_BASE
+
+
+@dataclass
+class RepoConfig:
+    name:           str
+    languages:      list        = field(default_factory=list)
+    url:            str | None  = None
+    ref:            str | None  = None
+    path:           str | None  = None
+    clone_to:       str | None  = None
+    ignore_dirs:    list        = field(default_factory=list)  # dir names to skip
+    extra_args:     list        = field(default_factory=list)  # passed through to treepeat detect
+    enabled:        bool        = True
+    notes:          str         = ""
+
+
+def load_config(toml_path: Path) -> tuple[Defaults, list[RepoConfig]]:
+    with open(toml_path, "rb") as f:
+        raw = tomllib.load(f)
+    defaults = Defaults(**{k: v for k, v in raw.get("defaults", {}).items()
+                            if k in Defaults.__dataclass_fields__})
+    repos = [RepoConfig(**{k: v for k, v in r.items()
+                            if k in RepoConfig.__dataclass_fields__})
+             for r in raw.get("repos", [])]
+    return defaults, repos
+
+
+def resolve_root(repo: RepoConfig, defaults: Defaults) -> Path:
+    if repo.path:
+        return Path(repo.path).expanduser()
+    base = Path(repo.clone_to).expanduser() if repo.clone_to \
+           else Path(defaults.clone_base).expanduser() / repo.name
+    return base
+
+
+# ---------------------------------------------------------------------------
+# File counting
+# ---------------------------------------------------------------------------
+
+
+def count_source_files(root: Path, ignore_dirs: list[str]) -> tuple[int, int]:
+    """Return (file_count, total_lines) for source files under root.
+
+    Skips _SKIP_DIRS, hidden dirs, and any dirs listed in ignore_dirs.
+    """
+    skip = _SKIP_DIRS | set(ignore_dirs)
+    total_files = 0
+    total_lines = 0
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            d for d in dirnames
+            if d not in skip and not d.startswith(".")
+        ]
+        for fname in filenames:
+            fpath = Path(dirpath) / fname
+            if fpath.suffix.lower() not in _KNOWN_EXTS:
+                continue
+            total_files += 1
+            try:
+                text = fpath.read_bytes()
+                total_lines += text.count(b"\n")
+            except OSError:
+                pass
+
+    return total_files, total_lines
+
+
+# ---------------------------------------------------------------------------
+# Repo cloning
+# ---------------------------------------------------------------------------
+
+CLONE_TIMEOUT_S = 300  # 5 minutes per clone
+
+
+def clone_repo(repo: RepoConfig, root: Path) -> bool:
+    """Clone repo.url to root, checking out repo.ref.  Returns True on success."""
+    if not repo.url:
+        print(f"  cannot clone {repo.name}: no url in config", file=sys.stderr)
+        return False
+
+    root.parent.mkdir(parents=True, exist_ok=True)
+    _emit(f"   cloning {repo.url} → {root}")
+
+    try:
+        subprocess.run(
+            ["git", "clone", "--depth", "1",
+             *(["--branch", repo.ref] if repo.ref else []),
+             repo.url, str(root)],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            timeout=CLONE_TIMEOUT_S,
+        )
+        return True
+    except subprocess.TimeoutExpired:
+        _emit(f"   git clone timed out after {CLONE_TIMEOUT_S}s — partial clone left at {root}")
+        shutil.rmtree(root, ignore_errors=True)
+        return False
+    except subprocess.CalledProcessError as exc:
+        err = exc.stderr.decode(errors="replace").strip() if exc.stderr else ""
+        _emit(f"   git clone failed: {err}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Treepeat runner
+# ---------------------------------------------------------------------------
+
+def _find_treepeat_binary() -> str | None:
+    """Find treepeat binary in venv or PATH."""
+    for name in ("treepeat", "treepeat.exe"):
+        candidate = VENV_BIN / name
+        if candidate.is_file():
+            return str(candidate)
+    return shutil.which("treepeat")
+
+
+def _kill_proc_group(proc: subprocess.Popen) -> None:
+    try:
+        pgid = os.getpgid(proc.pid)
+        os.killpg(pgid, signal.SIGTERM)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            os.killpg(pgid, signal.SIGKILL)
+            proc.wait()
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _parse_time_stats(stderr: str) -> dict:
+    """Parse /usr/bin/time output from stderr.
+
+    Returns dict with keys: peak_rss_mb, page_faults, swaps.
+
+    macOS -l output (bytes for RSS):
+        1234567  maximum resident set size
+          12345  page reclaims
+            678  page faults
+              0  swaps
+
+    Linux -v output (kbytes for RSS):
+        Maximum resident set size (kbytes): 12345
+        Major (requiring I/O) page faults: 678
+        Swaps: 0
+    """
+    stats: dict = {"peak_rss_mb": 0.0, "page_faults": 0, "swaps": 0}
+
+    if sys.platform == "darwin":
+        m = re.search(r"^\s*(\d+)\s+maximum resident set size", stderr, re.MULTILINE)
+        if m:
+            stats["peak_rss_mb"] = int(m.group(1)) / (1024 * 1024)
+        m = re.search(r"^\s*(\d+)\s+page faults", stderr, re.MULTILINE)
+        if m:
+            stats["page_faults"] = int(m.group(1))
+        m = re.search(r"^\s*(\d+)\s+swaps", stderr, re.MULTILINE)
+        if m:
+            stats["swaps"] = int(m.group(1))
+    else:
+        m = re.search(r"Maximum resident set size \(kbytes\):\s*(\d+)", stderr)
+        if m:
+            stats["peak_rss_mb"] = int(m.group(1)) / 1024
+        m = re.search(r"Major \(requiring I/O\) page faults:\s*(\d+)", stderr)
+        if m:
+            stats["page_faults"] = int(m.group(1))
+        m = re.search(r"Swaps:\s*(\d+)", stderr)
+        if m:
+            stats["swaps"] = int(m.group(1))
+
+    return stats
+
+
+def _parse_stage_counts(text: str) -> dict:
+    """Extract per-stage counts and elapsed times from treepeat stdout (ANSI-stripped).
+
+    Parses both counts ("Parse complete: N succeeded") and the inline stage
+    timings treepeat emits in parentheses ("Parse complete: N succeeded (24.6s)").
+    """
+    clean = _strip_ansi(text)
+    counts: dict = {}
+
+    m = re.search(r"Parse complete:\s*(\d+) succeeded.*?\(([\d.]+)s\)", clean)
+    if m:
+        counts["parse_succeeded"] = int(m.group(1))
+        counts["t_parse_s"]       = float(m.group(2))
+    else:
+        m = re.search(r"Parse complete:\s*(\d+) succeeded", clean)
+        if m:
+            counts["parse_succeeded"] = int(m.group(1))
+
+    m = re.search(r"Extracted (\d+) total region", clean)
+    if m:
+        counts["regions_extracted"] = int(m.group(1))
+    m = re.search(r"Extracted \d+ region\(s\) from \d+ file\(s\) \(([\d.]+)s\)", clean)
+    if m:
+        counts["t_extract_s"] = float(m.group(1))
+
+    m = re.search(r"Shingling (\d+) region\(s\) across", clean)
+    if m:
+        counts["regions_to_shingle"] = int(m.group(1))
+
+    m = re.search(r"Shingling complete:\s*(\d+) region.*?\(([\d.]+)s\)", clean)
+    if m:
+        counts["regions_shingled"] = int(m.group(1))
+        counts["t_shingle_s"]      = float(m.group(2))
+    else:
+        m = re.search(r"Shingling complete:\s*(\d+) region", clean)
+        if m:
+            counts["regions_shingled"] = int(m.group(1))
+
+    m = re.search(r"Created (\d+) signature.*?\(([\d.]+)s\)", clean)
+    if m:
+        counts["signatures"]  = int(m.group(1))
+        counts["t_minhash_s"] = float(m.group(2))
+    else:
+        m = re.search(r"Created (\d+) signature", clean)
+        if m:
+            counts["signatures"] = int(m.group(1))
+
+    m = re.search(r"found (\d+) similar group.*?\(([\d.]+)s\)", clean)
+    if m:
+        counts["groups_found"] = int(m.group(1))
+        counts["t_lsh_s"]      = float(m.group(2))
+    else:
+        m = re.search(r"found (\d+) similar group", clean)
+        if m:
+            counts["groups_found"] = int(m.group(1))
+
+    return counts
+
+
+def _count_sarif_clones(sarif_path: Path) -> int:
+    """Count clone results in SARIF output file."""
+    try:
+        data = json.loads(sarif_path.read_text(encoding="utf-8"))
+        total = 0
+        for run in data.get("runs", []):
+            total += len(run.get("results", []))
+        return total
+    except Exception:
+        return -1
+
+
+def _find_treepeat_child_pid(wrapper_pid: int) -> int | None:
+    """Return the PID of the treepeat child spawned by /usr/bin/time."""
+    try:
+        out = subprocess.check_output(
+            ["pgrep", "-P", str(wrapper_pid)],
+            stderr=subprocess.DEVNULL,
+        )
+        pids = out.decode().split()
+        return int(pids[0]) if pids else None
+    except Exception:
+        return None
+
+
+def _poll_rss(
+    wrapper_pid: int,
+    t0: float,
+    stop: threading.Event,
+    interval_s: float,
+    samples: list,
+    use_wrapper: bool,
+) -> None:
+    """Background thread: sample RSS every interval_s seconds.
+
+    When /usr/bin/time wraps treepeat, wrapper_pid is /usr/bin/time's PID
+    and we look for its child (the actual treepeat process).  When no wrapper
+    is used (use_wrapper=False), wrapper_pid IS treepeat's PID.
+    """
+    target_pid: int | None = None
+
+    while not stop.wait(interval_s):
+        if target_pid is None:
+            if use_wrapper:
+                target_pid = _find_treepeat_child_pid(wrapper_pid)
+            else:
+                target_pid = wrapper_pid
+
+        pid = target_pid if target_pid is not None else wrapper_pid
+
+        try:
+            rss_out = subprocess.check_output(
+                ["ps", "-p", str(pid), "-o", "rss="],
+                stderr=subprocess.DEVNULL,
+            )
+            rss_kb = rss_out.strip()
+            if rss_kb:
+                rss_mb = int(rss_kb) / 1024
+                elapsed = time.monotonic() - t0
+                samples.append([elapsed, rss_mb])
+        except Exception:
+            break
+
+
+def run_treepeat(
+    repo: RepoConfig,
+    root: Path,
+    timeout_s: int,
+    dry_run: bool,
+    log_path: Path,
+) -> PerfResult:
+    """Run treepeat on a repo and return performance metrics."""
+    result = PerfResult(
+        name=repo.name,
+        root=str(root),
+        languages=list(repo.languages),
+    )
+
+    result.src_files, result.src_lines = count_source_files(root, repo.ignore_dirs)
+
+    if dry_run:
+        return result
+
+    binary = _find_treepeat_binary()
+    if binary is None:
+        result.error = "treepeat binary not found"
+        return result
+
+    ignore_globs = ",".join(f"**/{d}/**" for d in repo.ignore_dirs if d)
+
+    with tempfile.NamedTemporaryFile(suffix=".sarif", delete=False) as tmp:
+        sarif_path = Path(tmp.name)
+
+    try:
+        cmd = [
+            binary,
+            "-l", "INFO",
+            "-r", DEFAULT_RULESET,
+            "detect", str(root),
+            "-f", "sarif",
+            "-o", str(sarif_path),
+            "--min-lines", str(DEFAULT_MIN_LINES),
+        ]
+        if ignore_globs:
+            cmd += ["--ignore", ignore_globs]
+        if repo.extra_args:
+            cmd += repo.extra_args
+
+        time_flag = "-l" if sys.platform == "darwin" else "-v"
+        use_wrapper = os.path.exists(_USR_BIN_TIME) and _time_wrapper_ok()
+        if os.path.exists(_USR_BIN_TIME) and not use_wrapper:
+            _emit(
+                f"WARNING: /usr/bin/time does not support {time_flag} on this "
+                f"platform — peak RSS, page-fault, and swap data will be "
+                f"unavailable; polled RSS is the only memory source"
+            )
+        if use_wrapper:
+            cmd = [_USR_BIN_TIME, time_flag] + cmd
+
+        t0 = time.monotonic()
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+
+        rss_samples: list = []
+        stop_event = threading.Event()
+        poll_thread = threading.Thread(
+            target=_poll_rss,
+            args=(proc.pid, t0, stop_event, 15.0, rss_samples, use_wrapper),
+            daemon=True,
+        )
+        poll_thread.start()
+
+        try:
+            stdout_bytes, stderr_bytes = proc.communicate(timeout=timeout_s)
+            result.elapsed_s = time.monotonic() - t0
+        except subprocess.TimeoutExpired:
+            result.elapsed_s = time.monotonic() - t0
+            _kill_proc_group(proc)
+            try:
+                stdout_bytes, stderr_bytes = proc.communicate(timeout=5)
+            except Exception:
+                stdout_bytes = b""
+                stderr_bytes = b""
+            result.timed_out = True
+        finally:
+            stop_event.set()
+            poll_thread.join(timeout=5)
+
+        result.rss_samples = rss_samples
+        if rss_samples:
+            result.peak_polled_rss_mb = max(mb for _, mb in rss_samples)
+
+        stdout_text = stdout_bytes.decode(errors="replace")
+        stderr_text = stderr_bytes.decode(errors="replace")
+
+        with open(log_path, "a", encoding="utf-8") as lf:
+            lf.write(f"\n{'='*60}\n{repo.name}  ({root})\n{'='*60}\n")
+            lf.write(f"cmd: {' '.join(cmd)}\n")
+            lf.write(f"elapsed: {result.elapsed_s:.1f}s  timed_out: {result.timed_out}\n")
+            lf.write("\n--- STDOUT ---\n")
+            lf.write(stdout_text or "(empty)\n")
+            lf.write("\n--- STDERR ---\n")
+            lf.write(stderr_text or "(empty)\n")
+
+        counts = _parse_stage_counts(stdout_text)
+        for k, v in counts.items():
+            setattr(result, k, v)
+
+        if result.timed_out:
+            pass
+        elif proc.returncode != 0:
+            result.error = f"exit {proc.returncode}"
+            ts = _parse_time_stats(stderr_text)
+            result.peak_rss_mb = ts["peak_rss_mb"]
+            result.page_faults = ts["page_faults"]
+            result.swaps       = ts["swaps"]
+        else:
+            ts = _parse_time_stats(stderr_text)
+            result.peak_rss_mb  = ts["peak_rss_mb"]
+            result.page_faults  = ts["page_faults"]
+            result.swaps        = ts["swaps"]
+            result.sarif_clones = _count_sarif_clones(sarif_path)
+
+    finally:
+        sarif_path.unlink(missing_ok=True)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+_CSV_FIELDS = [
+    "name", "languages",
+    "src_files", "src_lines",
+    "parse_succeeded", "regions_extracted", "regions_to_shingle", "regions_shingled",
+    "signatures", "groups_found", "sarif_clones",
+    "t_parse_s", "t_extract_s", "t_shingle_s", "t_minhash_s", "t_lsh_s",
+    "elapsed_s", "peak_rss_mb", "peak_polled_rss_mb", "rss_sample_count", "page_faults", "swaps",
+    "timed_out", "error",
+]
+
+
+def write_csv(results: list[PerfResult], csv_path: Path) -> None:
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=_CSV_FIELDS)
+        writer.writeheader()
+        for r in results:
+            row = asdict(r)
+            row["languages"] = "+".join(r.languages)
+            row["rss_sample_count"] = len(r.rss_samples)
+            writer.writerow({k: row[k] for k in _CSV_FIELDS})
+
+
+def write_json(results: list[PerfResult], json_path: Path) -> None:
+    data = [asdict(r) for r in results]
+    json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def print_summary(results: list[PerfResult]) -> None:
+    """Print a human-readable results table to stdout."""
+    cols = [
+        ("Repo",       "name",               18),
+        ("Lang",       "languages",           8),
+        ("SrcFiles",   "src_files",           9),
+        ("Shingled",   "regions_to_shingle",  8),
+        ("Clones",     "sarif_clones",        6),
+        ("tParse",     "t_parse_s",           7),
+        ("tExtract",   "t_extract_s",         8),
+        ("tShingle",   "t_shingle_s",         8),
+        ("tMinHash",   "t_minhash_s",         8),
+        ("tLSH",       "t_lsh_s",             8),
+        ("Total",      "elapsed_s",           8),
+        ("RSS(time)",  "peak_rss_mb",          9),
+        ("RSS(poll)",  "peak_polled_rss_mb",   9),
+        ("Faults",     "page_faults",         8),
+        ("OK?",        None,                   5),
+    ]
+
+    sep = "  ".join("─" * w for _, _, w in cols)
+    header = "  ".join(f"{label:<{w}}" for label, _, w in cols)
+    print()
+    print(header)
+    print(sep)
+
+    for r in results:
+        def _fmt(attr, w):
+            if attr is None:
+                if r.timed_out:
+                    v = "TOUT"
+                elif r.error:
+                    v = "ERR"
+                else:
+                    v = "✓"
+                return f"{v:<{w}}"
+            val = getattr(r, attr)
+            if attr == "languages":
+                val = "+".join(val)
+            if isinstance(val, float):
+                val = f"{val:.1f}"
+            return f"{str(val):<{w}}"
+
+        row = "  ".join(_fmt(attr, w) for _, attr, w in cols)
+        print(row)
+
+    print()
+
+
+def _emit(msg: str) -> None:
+    ts = datetime.now().strftime("%H:%M:%S")
+    print(f"{ts}  {msg}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def _default_config_path() -> Path:
+    return Path(__file__).with_name("perf_repos.toml")
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Treepeat performance characterization harness",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument("--config", metavar="PATH", type=Path,
+                   default=_default_config_path(),
+                   help=f"TOML config file (default: {_default_config_path().name} next to this script)")
+    p.add_argument("--repo", metavar="NAME",
+                   help="Run only this repo (by name)")
+    p.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_S, metavar="S",
+                   help=f"Per-repo timeout in seconds (default: {DEFAULT_TIMEOUT_S})")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Count files only, do not run treepeat")
+    p.add_argument("--clone", action="store_true",
+                   help="Clone missing repos before running (requires url in config)")
+    p.add_argument("--output-dir", metavar="DIR", type=Path,
+                   default=REPO_ROOT / "tools" / "perf" / "output",
+                   help="Directory for output files (default: <repo_root>/tools/perf/output)")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    if not args.config.exists():
+        print(f"Config not found: {args.config}", file=sys.stderr)
+        print("Create a perf_repos.toml — see the module docstring for format.", file=sys.stderr)
+        sys.exit(1)
+
+    defaults, all_repos = load_config(args.config)
+    repos = [r for r in all_repos if r.enabled]
+
+    if args.repo:
+        repos = [r for r in repos if r.name == args.repo]
+        if not repos:
+            print(f"No enabled repo named '{args.repo}' in {args.config}", file=sys.stderr)
+            sys.exit(1)
+
+    if not repos:
+        print("No enabled repos in config.", file=sys.stderr)
+        sys.exit(1)
+
+    # Verify roots exist; optionally clone missing ones
+    ready = []
+    for r in repos:
+        root = resolve_root(r, defaults)
+        if not root.exists():
+            if args.clone:
+                ok = clone_repo(r, root)
+                if not ok:
+                    _emit(f"SKIP {r.name}: clone failed")
+                    continue
+            else:
+                _emit(f"SKIP {r.name}: root not found: {root}")
+                _emit("       → clone it manually or re-run with --clone")
+                continue
+        ready.append((r, root))
+
+    if not ready:
+        print("No repo roots found. Use --clone to clone missing repos.", file=sys.stderr)
+        sys.exit(1)
+
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_path  = output_dir / f"run_{ts}.log"
+    csv_path  = output_dir / f"run_{ts}.csv"
+    json_path = output_dir / f"run_{ts}.json"
+
+    binary = _find_treepeat_binary()
+    mode = "(dry-run)" if args.dry_run else f"timeout={args.timeout}s ruleset={DEFAULT_RULESET}"
+    _emit(f"treepeat_perf  {ts}  {len(ready)} repo(s)  {mode}")
+    if binary and not args.dry_run:
+        _emit(f"treepeat: {binary}")
+    _emit(f"log: {log_path}")
+    print()
+
+    results: list[PerfResult] = []
+
+    for repo, root in ready:
+        lang_str = "+".join(repo.languages) if repo.languages else "?"
+        _emit(f"── {repo.name} ({lang_str})  src_root={root.name}")
+
+        result = run_treepeat(
+            repo=repo,
+            root=root,
+            timeout_s=args.timeout,
+            dry_run=args.dry_run,
+            log_path=log_path,
+        )
+        results.append(result)
+
+        if args.dry_run:
+            _emit(f"   {result.src_files} src files  {result.src_lines:,} lines")
+        elif result.error:
+            _emit(f"   ✗ error: {result.error}  ({result.elapsed_s:.1f}s)")
+        elif result.timed_out:
+            rss_note = (f"  rss_peak={result.peak_rss_mb:.0f}MiB"
+                        f" ({len(result.rss_samples)} samples)"
+                        if result.rss_samples else "")
+            _emit(f"   ✗ TIMEOUT after {result.elapsed_s:.0f}s{rss_note}")
+        else:
+            rss    = (f"  rss={result.peak_rss_mb:.0f}MiB(time)/{result.peak_polled_rss_mb:.0f}MiB(poll)"
+                      if result.peak_rss_mb or result.peak_polled_rss_mb else "")
+            faults = f"  pfaults={result.page_faults:,}" if result.page_faults else ""
+            swaps  = f"  swaps={result.swaps}" if result.swaps else ""
+            _emit(
+                f"   ✓ {result.elapsed_s:.1f}s{rss}{faults}{swaps}"
+                f"  files={result.src_files}"
+                f"  parsed={result.parse_succeeded}"
+                f"  regions={result.regions_extracted}"
+                f"  shingled={result.regions_shingled}"
+                f"  clones={result.sarif_clones}"
+            )
+
+    print_summary(results)
+
+    if not args.dry_run:
+        write_csv(results, csv_path)
+        write_json(results, json_path)
+        _emit(f"CSV:  {csv_path}")
+        _emit(f"JSON: {json_path}")
+    _emit(f"Log:  {log_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf/harness.py
+++ b/tools/perf/harness.py
@@ -1,59 +1,3 @@
-"""tools/perf/harness.py — Treepeat performance characterization harness.
-
-Runs treepeat on repos defined in a TOML config file (default: perf_repos.toml
-in this directory).  Captures wall-clock time, peak RSS (/usr/bin/time -l),
-per-stage counts from INFO logs, and clone count from SARIF output.
-
-Goal: establish the file-count / SLOC / clone-density vs. time+memory curve
-to guide treepeat's optimization roadmap and validate the swapping hypothesis
-(suspected around 2000–3000 source files on a 32GB MacBook).
-
-Usage:
-    python tools/perf/harness.py
-    python tools/perf/harness.py --repo requests
-    python tools/perf/harness.py --timeout 600
-    python tools/perf/harness.py --dry-run
-    python tools/perf/harness.py --clone           # auto-clone missing repos
-    python tools/perf/harness.py --config my_repos.toml
-
-Config file format (TOML):
-    [defaults]
-    clone_base = "~/.config/treepeat-dev"   # where to clone repos
-
-    [[repos]]
-    name       = "requests"
-    url        = "https://github.com/psf/requests"
-    ref        = "v2.33.1"
-    languages  = ["python"]
-    notes      = "Small, clean baseline"
-
-    [[repos]]
-    name        = "django"
-    url         = "https://github.com/django/django"
-    ref         = "4.2"
-    languages   = ["python"]
-    ignore_dirs = ["docs"]
-
-Output (tools/perf/output/ under the treepeat repo root, or --output-dir):
-    run_<ts>.log    captured stdout+stderr for each repo
-    run_<ts>.csv    one row per repo — import into a spreadsheet for curve fitting
-    run_<ts>.json   structured results (full, machine-readable)
-
-Wishlist for future treepeat improvements that would enhance perf instrumentation:
-  1. Per-stage elapsed time: emit "Stage N/5: <name> [elapsed Xs]" to stderr so
-     per-stage wall time is available independent of output format.
-  2. --verbose with -f sarif: currently verbose metrics go to stdout only in
-     console mode; should also work in sarif mode (output to stderr).
-  3. Peak RSS self-reporting: emit resource.getrusage(RUSAGE_SELF).ru_maxrss
-     to stderr at pipeline end — avoids /usr/bin/time wrapper requirement.
-  4. Region count per stage to stderr: parse_succeeded, regions_extracted,
-     shingled, signatures already logged at INFO; consider a structured
-     "PERF" log line at WARNING level so it's always visible.
-  5. --min-regions: option to skip repos with < N extracted regions to allow
-     quick early-exit on effectively-empty scans.
-"""
-
-import argparse
 import csv
 import functools
 import json
@@ -70,6 +14,12 @@ import tomllib
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from pathlib import Path
+
+import click
+import psutil
+from rich import box
+from rich.console import Console
+from rich.table import Table
 
 
 # ---------------------------------------------------------------------------
@@ -468,13 +418,10 @@ def _count_sarif_clones(sarif_path: Path) -> int:
 def _find_treepeat_child_pid(wrapper_pid: int) -> int | None:
     """Return the PID of the treepeat child spawned by /usr/bin/time."""
     try:
-        out = subprocess.check_output(
-            ["pgrep", "-P", str(wrapper_pid)],
-            stderr=subprocess.DEVNULL,
-        )
-        pids = out.decode().split()
-        return int(pids[0]) if pids else None
-    except Exception:
+        parent = psutil.Process(wrapper_pid)
+        children = parent.children()
+        return children[0].pid if children else None
+    except (psutil.Error, ProcessLookupError):
         return None
 
 
@@ -497,17 +444,12 @@ def _poll_rss(
     def _sample(pid: int) -> bool:
         """Sample RSS for pid; return False if the process has exited."""
         try:
-            rss_out = subprocess.check_output(
-                ["ps", "-p", str(pid), "-o", "rss="],
-                stderr=subprocess.DEVNULL,
-            )
-            rss_kb = rss_out.strip()
-            if rss_kb:
-                rss_mb = int(rss_kb) / 1024
-                elapsed = time.monotonic() - t0
-                samples.append([elapsed, rss_mb])
+            rss_bytes = psutil.Process(pid).memory_info().rss
+            rss_mb = rss_bytes / (1024 * 1024)
+            elapsed = time.monotonic() - t0
+            samples.append([elapsed, rss_mb])
             return True
-        except Exception:
+        except (psutil.Error, ProcessLookupError):
             return False
 
     # Take an immediate sample so short runs (< interval_s) still get data.
@@ -693,52 +635,75 @@ def write_json(results: list[PerfResult], json_path: Path) -> None:
     json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
-def print_summary(results: list[PerfResult]) -> None:
-    """Print a human-readable results table to stdout."""
-    cols = [
-        ("Repo",       "name",               18),
-        ("Lang",       "languages",           8),
-        ("SrcFiles",   "src_files",           9),
-        ("Shingled",   "regions_to_shingle",  8),
-        ("Clones",     "sarif_clones",        6),
-        ("tParse",     "t_parse_s",           7),
-        ("tExtract",   "t_extract_s",         8),
-        ("tShingle",   "t_shingle_s",         8),
-        ("tMinHash",   "t_minhash_s",         8),
-        ("tLSH",       "t_lsh_s",             8),
-        ("Total",      "elapsed_s",           8),
-        ("RSS(time)",  "peak_rss_mb",          9),
-        ("RSS(poll)",  "peak_polled_rss_mb",   9),
-        ("Faults",     "page_faults",         8),
-        ("OK?",        None,                   5),
-    ]
+def _status_symbol(result: PerfResult) -> str:
+    if result.timed_out:
+        return "⏱"
+    if result.error:
+        return "✗"
+    return "✓"
 
-    sep = "  ".join("─" * w for _, _, w in cols)
-    header = "  ".join(f"{label:<{w}}" for label, _, w in cols)
+
+def _mem_mb(result: PerfResult) -> float:
+    return max(result.peak_rss_mb, result.peak_polled_rss_mb)
+
+
+def _format_mem(result: PerfResult) -> str:
+    mem_mb = _mem_mb(result)
+    return f"{mem_mb:.0f}M" if mem_mb else "0M"
+
+
+def _build_result_table(include_repo: bool) -> Table:
+    console = Console()
+    table = Table(box=box.SIMPLE_HEAVY, expand=False)
+    table.add_column("", justify="center", width=1, no_wrap=True)
+    if include_repo:
+        table.add_column("Repo", no_wrap=True)
+    table.add_column("File", justify="right", no_wrap=True)
+    table.add_column("Shngs", justify="right", no_wrap=True)
+    table.add_column("Pair", justify="right", no_wrap=True)
+    table.add_column("Clon", justify="right", no_wrap=True)
+    table.add_column("Shng", justify="right", no_wrap=True)
+    table.add_column("Hash", justify="right", no_wrap=True)
+    table.add_column("LSH", justify="right", no_wrap=True)
+    table.add_column("Mem", justify="right", no_wrap=True)
+    return table, console
+
+
+def _add_result_row(table: Table, result: PerfResult, include_repo: bool) -> None:
+    row = [_status_symbol(result)]
+    if include_repo:
+        row.append(result.name)
+    row.extend([
+        str(result.src_files),
+        str(result.regions_shingled),
+        str(result.candidate_pairs),
+        str(result.sarif_clones),
+        f"{result.t_shingle_s:.1f}",
+        f"{result.t_minhash_s:.1f}",
+        f"{result.t_lsh_s:.1f}",
+        _format_mem(result),
+    ])
+    table.add_row(*row)
+
+
+def print_repo_summary(result: PerfResult) -> None:
+    """Print a compact per-repo summary table."""
+    table, console = _build_result_table(include_repo=False)
+    _add_result_row(table, result, include_repo=False)
     print()
-    print(header)
-    print(sep)
+    console.print(table)
+    print()
+
+
+def print_summary(results: list[PerfResult]) -> None:
+    """Print a human-readable end-of-run summary table."""
+    table, console = _build_result_table(include_repo=True)
 
     for r in results:
-        def _fmt(attr, w):
-            if attr is None:
-                if r.timed_out:
-                    v = "TOUT"
-                elif r.error:
-                    v = "ERR"
-                else:
-                    v = "✓"
-                return f"{v:<{w}}"
-            val = getattr(r, attr)
-            if attr == "languages":
-                val = "+".join(val)
-            if isinstance(val, float):
-                val = f"{val:.1f}"
-            return f"{str(val):<{w}}"
+        _add_result_row(table, r, include_repo=True)
 
-        row = "  ".join(_fmt(attr, w) for _, attr, w in cols)
-        print(row)
-
+    print()
+    console.print(table)
     print()
 
 
@@ -755,56 +720,74 @@ def _default_config_path() -> Path:
     return Path(__file__).with_name("perf_repos.toml")
 
 
-def _parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(
-        description="Treepeat performance characterization harness",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__,
-    )
-    p.add_argument("--config", metavar="PATH", type=Path,
-                   default=_default_config_path(),
-                   help=f"TOML config file (default: {_default_config_path().name} next to this script)")
-    p.add_argument("--repo", metavar="NAME",
-                   help="Run only this repo (by name)")
-    p.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_S, metavar="S",
-                   help=f"Per-repo timeout in seconds (default: {DEFAULT_TIMEOUT_S})")
-    p.add_argument("--dry-run", action="store_true",
-                   help="Count files only, do not run treepeat")
-    p.add_argument("--clone", action="store_true",
-                   help="Clone missing repos before running (requires url in config)")
-    p.add_argument("--output-dir", metavar="DIR", type=Path,
-                   default=REPO_ROOT / "tools" / "perf" / "output",
-                   help="Directory for output files (default: <repo_root>/tools/perf/output)")
-    return p.parse_args()
+@click.command()
+@click.option(
+    "--config",
+    type=click.Path(path_type=Path),
+    default=_default_config_path,
+    show_default=True,
+    help="TOML config file.",
+)
+@click.option(
+    "--repo",
+    help="Run only this repo (by name).",
+)
+@click.option(
+    "--timeout",
+    type=click.IntRange(1),
+    default=DEFAULT_TIMEOUT_S,
+    show_default=True,
+    help="Per-repo timeout in seconds.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Count files only, do not run treepeat.",
+)
+@click.option(
+    "--clone",
+    "clone_missing",
+    is_flag=True,
+    help="Clone missing repos before running (requires url in config).",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(path_type=Path),
+    default=REPO_ROOT / "tools" / "perf" / "output",
+    show_default=True,
+    help="Directory for output files.",
+)
+def main(
+    config: Path,
+    repo: str | None,
+    timeout: int,
+    dry_run: bool,
+    clone_missing: bool,
+    output_dir: Path,
+) -> None:
+    """Treepeat performance characterization harness."""
+    if not config.exists():
+        raise click.ClickException(
+            f"Config not found: {config}\nCreate a perf_repos.toml in tools/perf/ or pass --config."
+        )
 
-
-def main() -> None:
-    args = _parse_args()
-
-    if not args.config.exists():
-        print(f"Config not found: {args.config}", file=sys.stderr)
-        print("Create a perf_repos.toml — see the module docstring for format.", file=sys.stderr)
-        sys.exit(1)
-
-    defaults, all_repos = load_config(args.config)
+    defaults, all_repos = load_config(config)
     repos = [r for r in all_repos if r.enabled]
 
-    if args.repo:
-        repos = [r for r in repos if r.name == args.repo]
+    if repo:
+        repos = [r for r in repos if r.name == repo]
         if not repos:
-            print(f"No enabled repo named '{args.repo}' in {args.config}", file=sys.stderr)
-            sys.exit(1)
+            raise click.ClickException(f"No enabled repo named '{repo}' in {config}")
 
     if not repos:
-        print("No enabled repos in config.", file=sys.stderr)
-        sys.exit(1)
+        raise click.ClickException("No enabled repos in config.")
 
     # Verify roots exist; optionally clone missing ones
     ready = []
     for r in repos:
         root = resolve_root(r, defaults)
         if not root.exists():
-            if args.clone:
+            if clone_missing:
                 ok = clone_repo(r, root)
                 if not ok:
                     _emit(f"SKIP {r.name}: clone failed")
@@ -816,10 +799,8 @@ def main() -> None:
         ready.append((r, root))
 
     if not ready:
-        print("No repo roots found. Use --clone to clone missing repos.", file=sys.stderr)
-        sys.exit(1)
+        raise click.ClickException("No repo roots found. Use --clone to clone missing repos.")
 
-    output_dir: Path = args.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     log_path  = output_dir / f"run_{ts}.log"
@@ -827,9 +808,9 @@ def main() -> None:
     json_path = output_dir / f"run_{ts}.json"
 
     binary = _find_treepeat_binary()
-    mode = "(dry-run)" if args.dry_run else f"timeout={args.timeout}s ruleset={DEFAULT_RULESET}"
+    mode = "(dry-run)" if dry_run else f"timeout={timeout}s ruleset={DEFAULT_RULESET}"
     _emit(f"treepeat_perf  {ts}  {len(ready)} repo(s)  {mode}")
-    if binary and not args.dry_run:
+    if binary and not dry_run:
         _emit(f"treepeat: {binary}")
     _emit(f"log: {log_path}")
     print()
@@ -843,21 +824,24 @@ def main() -> None:
         result = run_treepeat(
             repo=repo,
             root=root,
-            timeout_s=args.timeout,
-            dry_run=args.dry_run,
+            timeout_s=timeout,
+            dry_run=dry_run,
             log_path=log_path,
         )
         results.append(result)
 
-        if args.dry_run:
+        if dry_run:
             _emit(f"   {result.src_files} src files  {result.src_lines:,} lines")
+            print_repo_summary(result)
         elif result.error:
             _emit(f"   ✗ error: {result.error}  ({result.elapsed_s:.1f}s)")
+            print_repo_summary(result)
         elif result.timed_out:
             rss_note = (f"  rss_peak={result.peak_polled_rss_mb:.0f}MiB"
                         f" ({len(result.rss_samples)} samples)"
                         if result.rss_samples else "")
             _emit(f"   ✗ TIMEOUT after {result.elapsed_s:.0f}s{rss_note}")
+            print_repo_summary(result)
         else:
             rss    = (f"  rss={result.peak_rss_mb:.0f}MiB(time)/{result.peak_polled_rss_mb:.0f}MiB(poll)"
                       if result.peak_rss_mb or result.peak_polled_rss_mb else "")
@@ -869,12 +853,15 @@ def main() -> None:
                 f"  parsed={result.parse_succeeded}"
                 f"  regions={result.regions_extracted}"
                 f"  shingled={result.regions_shingled}"
+                f"  pairs={result.candidate_pairs}"
                 f"  clones={result.sarif_clones}"
             )
+            print_repo_summary(result)
 
-    print_summary(results)
+    if len(results) > 1:
+        print_summary(results)
 
-    if not args.dry_run:
+    if not dry_run:
         write_csv(results, csv_path)
         write_json(results, json_path)
         _emit(f"CSV:  {csv_path}")

--- a/tools/perf/harness.py
+++ b/tools/perf/harness.py
@@ -245,7 +245,7 @@ def clone_repo(repo: RepoConfig, root: Path) -> bool:
                 timeout=CLONE_TIMEOUT_S,
             )
             subprocess.run(
-                ["git", "-C", str(root), "checkout", ref],
+                ["git", "-C", str(root), "checkout", str(ref)],
                 check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
                 timeout=60,
             )
@@ -652,7 +652,7 @@ def _format_mem(result: PerfResult) -> str:
     return f"{mem_mb:.0f}M" if mem_mb else "0M"
 
 
-def _build_result_table(include_repo: bool) -> Table:
+def _build_result_table(include_repo: bool) -> tuple[Table, Console]:
     console = Console()
     table = Table(box=box.SIMPLE_HEAVY, expand=False)
     table.add_column("", justify="center", width=1, no_wrap=True)

--- a/tools/perf/harness.py
+++ b/tools/perf/harness.py
@@ -171,6 +171,7 @@ class PerfResult:
     regions_shingled:  int   = 0    # "Shingling complete: N region(s)"
     signatures:        int   = 0    # "Created N signature(s)"
     groups_found:      int   = 0    # "found N similar group(s)"
+    candidate_pairs:   int   = 0    # "Total candidate pairs entering verification: N"
 
     # Per-stage elapsed times (seconds) parsed from inline "(Xs)" suffixes
     t_parse_s:         float = 0.0  # parse stage
@@ -445,6 +446,10 @@ def _parse_stage_counts(text: str) -> dict:
         if m:
             counts["groups_found"] = int(m.group(1))
 
+    m = re.search(r"Total candidate pairs entering verification:\s*(\d+)", clean)
+    if m:
+        counts["candidate_pairs"] = int(m.group(1))
+
     return counts
 
 
@@ -665,7 +670,7 @@ _CSV_FIELDS = [
     "name", "languages",
     "src_files", "src_lines",
     "parse_succeeded", "regions_extracted", "regions_to_shingle", "regions_shingled",
-    "signatures", "groups_found", "sarif_clones",
+    "signatures", "groups_found", "candidate_pairs", "sarif_clones",
     "t_parse_s", "t_extract_s", "t_shingle_s", "t_minhash_s", "t_lsh_s",
     "elapsed_s", "peak_rss_mb", "peak_polled_rss_mb", "rss_sample_count", "page_faults", "swaps",
     "timed_out", "error",

--- a/tools/perf/perf_repos.toml
+++ b/tools/perf/perf_repos.toml
@@ -1,0 +1,80 @@
+# perf_repos.toml — repos for treepeat performance characterization
+#
+# Run:
+#   python tools/perf/harness.py --dry-run         # file census only
+#   python tools/perf/harness.py --clone           # clone + run all
+#   python tools/perf/harness.py --repo requests   # single repo
+#
+# Fields per [[repos]] entry:
+#   name       (required) — short identifier, used as clone dirname
+#   url        (optional) — git URL; required when using --clone
+#   ref        (optional) — branch, tag, or commit to check out
+#   path       (optional) — local path override (skips clone_base)
+#   clone_to   (optional) — per-repo clone path override
+#   languages  (optional) — informational, e.g. ["python"]
+#   ignore_dirs (optional) — directory names to exclude from census and treepeat scan
+#   extra_args (optional) — extra flags passed directly to `treepeat detect`
+#   enabled    (optional, default true) — set false to skip without removing
+#   notes      (optional) — free-form description
+
+[defaults]
+# Base directory where repos are cloned (one subdir per repo name).
+# Override per-repo with clone_to, or globally via --output-dir.
+clone_base = "~/.config/treepeat-dev"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Small / baseline
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[repos]]
+name      = "requests"
+url       = "https://github.com/psf/requests"
+ref       = "v2.33.1"
+languages = ["python"]
+enabled   = true
+notes     = "~40 source files at this tag. Clean, widely-used HTTP library — good low-noise baseline."
+
+[[repos]]
+name      = "flask"
+url       = "https://github.com/pallets/flask"
+ref       = "3.1.3"
+languages = ["python"]
+enabled   = true
+notes     = "~80 source files at this tag. Micro-framework; minimal structure, good small-Python data point."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Medium
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[repos]]
+name      = "redux-toolkit"
+url       = "https://github.com/reduxjs/redux-toolkit"
+ref       = "v2.9.2"
+languages = ["typescript"]
+enabled   = true
+notes     = "~650 source files at this tag. Clean TS monorepo; good mid-size TypeScript data point."
+
+[[repos]]
+name        = "nestjs"
+url         = "https://github.com/nestjs/nest"
+ref         = "v9.4.3"
+languages   = ["typescript"]
+ignore_dirs = ["node_modules"]
+enabled   = true
+notes     = "~1600 source files at this tag. Enterprise Node.js framework; DI + decorators."
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Large / stress tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[repos]]
+name        = "django"
+url         = "https://github.com/django/django"
+ref         = "4.2"
+languages   = ["python"]
+ignore_dirs = ["docs"]
+enabled   = true
+notes     = "~2800 source files at this tag. Large Python framework; docs/ excluded (non-source)."

--- a/tools/perf/perf_repos.toml
+++ b/tools/perf/perf_repos.toml
@@ -1,9 +1,10 @@
 # perf_repos.toml — repos for treepeat performance characterization
 #
 # Run:
-#   python tools/perf/harness.py --dry-run         # file census only
-#   python tools/perf/harness.py --clone           # clone + run all
-#   python tools/perf/harness.py --repo requests   # single repo
+#   make setup
+#   uv run python tools/perf/harness.py --dry-run         # file census only
+#   uv run python tools/perf/harness.py --clone           # clone + run all
+#   uv run python tools/perf/harness.py --repo requests   # single repo
 #
 # Fields per [[repos]] entry:
 #   name       (required) — short identifier, used as clone dirname

--- a/tools/perf/perf_repos.toml
+++ b/tools/perf/perf_repos.toml
@@ -19,7 +19,7 @@
 
 [defaults]
 # Base directory where repos are cloned (one subdir per repo name).
-# Override per-repo with clone_to, or globally via --output-dir.
+# Override per-repo with clone_to or path; use --output-dir only for result files.
 clone_base = "~/.config/treepeat-dev"
 
 

--- a/treepeat/pipeline/lsh_stage.py
+++ b/treepeat/pipeline/lsh_stage.py
@@ -441,6 +441,11 @@ def detect_similarity(
         progress=progress,
     )
 
+    total_pairs = sum(
+        len(g.regions) * (len(g.regions) - 1) // 2 for g in candidate_groups
+    )
+    logger.info("Total candidate pairs entering verification: %d", total_pairs)
+
     if not candidate_groups:
         return SimilarityResult(
             signatures=filtered_signatures,

--- a/uv.lock
+++ b/uv.lock
@@ -427,6 +427,34 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.4"
 source = { registry = "https://pypi.org/simple" }
@@ -911,6 +939,14 @@ version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/22/85/a61c782afbb706a47d990eaee6977e7c2bd013771c5bf5c81c617684f286/tree_sitter_c_sharp-0.23.1.tar.gz", hash = "sha256:322e2cfd3a547a840375276b2aea3335fa6458aeac082f6c60fec3f745c967eb", size = 1317728, upload-time = "2024-11-11T05:25:32.535Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/dc/d4a0ad9e466263728f80f9dac399609473af01c1aba2ea3ea8879ce56276/tree_sitter_c_sharp-0.23.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e87be7572991552606a3155d2f6c2045ded8bce94bfd9f74bf521d949c219a1c", size = 333661, upload-time = "2026-04-14T15:11:14.227Z" },
+    { url = "https://files.pythonhosted.org/packages/61/7a/5c862770460a2e27079e725585ad2718100373c09448c14e36934ef44414/tree_sitter_c_sharp-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:86c2fdf178c66474a1be2965602818d30780e4e3ed890e3c206931f65d9a154c", size = 376295, upload-time = "2026-04-14T15:11:15.346Z" },
+    { url = "https://files.pythonhosted.org/packages/67/18/0571a3a34c0feda60a9c37cf6dd5edfdbc24f8fcb1e48b6b6eb0f324ad2a/tree_sitter_c_sharp-0.23.1-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:035d259e64c41d02cc45afc3b8b46388b232e7d16d84734d851cca7334761da5", size = 358331, upload-time = "2026-04-14T15:11:16.418Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/0f7e1f50f6365338eb700f01710da0adc49a49fa9a8443e5a90ea4f29491/tree_sitter_c_sharp-0.23.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa472cb9de7e14fee9408e144f29f68384cd8e9c677dff0002da19f361a59bdf", size = 359444, upload-time = "2026-04-14T15:11:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/98/60/129bd56d5ef22b4ae254940a09b6d3ed873093218868a3f9635d571d514e/tree_sitter_c_sharp-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1a0ea86eccff74e85ab4a2cf77c813fad7c84162962ce242dff0c51601028832", size = 358143, upload-time = "2026-04-14T15:11:18.755Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/cd/e12cdca47e0c56151cb4b156d48091b7bc1d968e072c1656cf6b73fe7218/tree_sitter_c_sharp-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8ab26dc998bbd4b4287b129f67c10ca715deb402ed77d0645674490ea509097e", size = 357524, upload-time = "2026-04-14T15:11:19.717Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/2c/f742d60f818cba83760f4975c7158d1c96c36b5807e95a843db7fb8c64b7/tree_sitter_c_sharp-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:d4486653feaff3314ef45534dcb6f9ea8ab3aa160896287c6473788f88eb38be", size = 338755, upload-time = "2026-04-14T15:11:20.883Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e4/8a8642b9bba86248ac2facc81ffb187c06c6768efa56c79d61fab70d736b/tree_sitter_c_sharp-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:e7a14b76ec23cc8386cf662d5ea602d81331376c93ca6299a97b174047790345", size = 337261, upload-time = "2026-04-14T15:11:22.111Z" },
     { url = "https://files.pythonhosted.org/packages/58/04/f6c2df4c53a588ccd88d50851155945cff8cd887bd70c175e00aaade7edf/tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2b612a6e5bd17bb7fa2aab4bb6fc1fba45c94f09cb034ab332e45603b86e32fd", size = 372235, upload-time = "2024-11-11T05:25:19.424Z" },
     { url = "https://files.pythonhosted.org/packages/99/10/1aa9486f1e28fc22810fa92cbdc54e1051e7f5536a5e5b5e9695f609b31e/tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a8b98f62bc53efcd4d971151950c9b9cd5cbe3bacdb0cd69fdccac63350d83e", size = 419046, upload-time = "2024-11-11T05:25:20.679Z" },
     { url = "https://files.pythonhosted.org/packages/0f/21/13df29f8fcb9ba9f209b7b413a4764b673dfd58989a0dd67e9c7e19e9c2e/tree_sitter_c_sharp-0.23.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:986e93d845a438ec3c4416401aa98e6a6f6631d644bbbc2e43fcb915c51d255d", size = 415999, upload-time = "2024-11-11T05:25:22.359Z" },
@@ -993,6 +1029,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "psutil" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "radon" },
@@ -1018,6 +1055,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.10" },
     { name = "pre-commit", specifier = ">=3.7" },
+    { name = "psutil", specifier = ">=7.0.0" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-cov", specifier = ">=6" },
     { name = "radon", specifier = ">=6.0.1" },


### PR DESCRIPTION
## Summary

- Adds `tools/perf/harness.py`: a standalone script that runs `treepeat detect` on a set of real-world repos and records wall-clock time, peak RSS, per-stage counts, and SARIF clone count
- Adds `tools/perf/perf_repos.toml`: default config with 5 repos spanning small→large (requests, flask, redux-toolkit, nestjs, django)
- Adds `docs/perf-harness.md`: usage guide, config field reference, platform notes, and instrumentation wishlist
- Adds instructions in docs/perf-harness.md
- Updates `.gitignore` to exclude `tools/perf/output/`

## Motivation

Establishes a repeatable baseline for the time/memory vs. file-count curve, to guide optimization work and validate (or refute) the swapping hypothesis (~2,000–3,000 source files on a 32 GB machine).

## Design notes

- Config-driven (`[[repos]]` in TOML); `ignore_dirs` excludes dirs from both the file census and treepeat via `--ignore **/dir/**` glob; `extra_args` passes through directly to `treepeat detect`
- Memory is measured two ways: `/usr/bin/time -l/-v` for authoritative peak RSS on clean exit, and a background `ps` poller every 15 s (the only source on timeout)
- `/usr/bin/time` flag support is probed once via `lru_cache`; harness warns and falls back gracefully on Alpine/busybox
- `--clone` flag for first-time setup; 300s clone timeout with cleanup of partial clones on failure
- No new runtime dependencies (`tomllib` is stdlib in Python ≥ 3.11)
- Using tools/ directory

## Test plan

- [X] `python tools/perf/harness.py --dry-run` — file census, no treepeat invocation
- [X] `python tools/perf/harness.py --clone --repo requests` — end-to-end on smallest repo
- [X] `python tools/perf/harness.py --clone` — full run; check `tools/perf/output/run_*.csv`

Tested fresh checkout on linux and MacOS; confirmed repo cloning works, and tests run as expected.