### PR TITLE
Pre-partition rules by language for O(1) shingling dispatch

### DIFF
--- a/treepeat/pipeline/rules/engine.py
+++ b/treepeat/pipeline/rules/engine.py
@@ -28,7 +28,7 @@ class RuleEngine:
         # "*" entries are rules that match all languages.
         self._rules_by_language: dict[str, list[Rule]] = {}
         for rule in rules:
-            for lang in rule.languages:
+            for lang in set(rule.languages):
                 self._rules_by_language.setdefault(lang, []).append(rule)
         self._source: bytes | None = None  # Store source for value extraction
 

--- a/treepeat/pipeline/rules/engine.py
+++ b/treepeat/pipeline/rules/engine.py
@@ -24,6 +24,12 @@ class RuleEngine:
         self._action_handlers = self._build_action_handlers()
         self._compiled_queries: dict[tuple[str, str], Query] = {}
         self._query_matches_cache: dict[int, list[dict[str, Any]]] = {}
+        # Pre-partition rules by language for O(1) lookup during shingling.
+        # "*" entries are rules that match all languages.
+        self._rules_by_language: dict[str, list[Rule]] = {}
+        for rule in rules:
+            for lang in rule.languages:
+                self._rules_by_language.setdefault(lang, []).append(rule)
         self._source: bytes | None = None  # Store source for value extraction
 
     def _build_action_handlers(
@@ -221,8 +227,15 @@ class RuleEngine:
         return name, value
 
     def _iter_matching_rules(self, language: str) -> Iterable[Rule]:
-        for rule in self.rules:
-            if rule.matches_language(language):
+        # Yield wildcard rules first, then language-specific rules.
+        # Deduplication guard handles the (currently unused) case where a rule
+        # lists both "*" and a specific language in its languages field.
+        seen: set[int] = set()
+        for rule in self._rules_by_language.get("*", []):
+            seen.add(id(rule))
+            yield rule
+        for rule in self._rules_by_language.get(language, []):
+            if id(rule) not in seen:
                 yield rule
 
     def _apply_rule_state(
@@ -284,7 +297,7 @@ class RuleEngine:
 
         # Pre-execute all queries once and cache results indexed by node.id
         self._query_matches_cache = self._get_all_matches(
-            root_node, [r for r in self.rules if r.matches_language(language)], language
+            root_node, list(self._iter_matching_rules(language)), language
         )
 
     def get_region_extraction_rules(self, language: str) -> list[tuple[str, str]]:
@@ -293,8 +306,8 @@ class RuleEngine:
         Returns list of tuples: (query, region_type)
         """
         region_rules = []
-        for rule in self.rules:
-            if rule.action == RuleAction.EXTRACT_REGION and rule.matches_language(language):
+        for rule in self._iter_matching_rules(language):
+            if rule.action == RuleAction.EXTRACT_REGION:
                 region_type = rule.params.get("region_type")
                 if region_type:
                     region_rules.append((rule.query, region_type))

--- a/treepeat/pipeline/rules/engine.py
+++ b/treepeat/pipeline/rules/engine.py
@@ -230,8 +230,12 @@ class RuleEngine:
         # Yield wildcard rules first, then language-specific rules.
         # Deduplication guard handles the (currently unused) case where a rule
         # lists both "*" and a specific language in its languages field.
+        wildcard_rules = self._rules_by_language.get("*", [])
+        if not wildcard_rules:
+            yield from self._rules_by_language.get(language, [])
+            return
         seen: set[int] = set()
-        for rule in self._rules_by_language.get("*", []):
+        for rule in wildcard_rules:
             seen.add(id(rule))
             yield rule
         for rule in self._rules_by_language.get(language, []):


### PR DESCRIPTION
## Summary

- PR #93 addressed the O(n) signature lookup in the LSH stage. This PR takes the same profiling session's second finding further: `_iter_matching_rules` was called once per AST node during shingling, iterating all rules and calling `matches_language()` on each. On django (25,347 regions, ~6.2M AST node traversals) this added up to 112s CPU, with `matches_language()` alone consuming 87s across 632M calls.
- Build `_rules_by_language` , dict partitioned by language string, making `_iter_matching_rules` O(1).
- Two call sites that previously inlined the same filter (`precompute_queries`, `get_region_extraction_rules`) now delegate to `_iter_matching_rules`.
- A deduplication guard handles the edge case of a rule listing both `"*"` and a specific language.

## Performance

Note: PR #93 changes were temporarily applied to this branch, to give an updated relative 'before' baseline)

| Repo | Before | After | Δ |
|---|---|---|---|
| requests | 3.7s | 2.8s | −24% |
| flask | 4.3s | 3.2s | −26% |
| redux-toolkit | 32.8s | 25.0s | −24% |
| nestjs | 16.8s | 16.4s | −2% (noise) |
| django | 166.9s | 114.8s | −31% |

## Correctness

- All 96 existing tests pass
- Per-language tests (`test_python`, `test_java`, etc.) serve as integration coverage for correct rule dispatch
- Clone counts on five real repos are unchanged
- **Note:** this partitions *rule application* during shingling, not clone detection — regions from different languages are still compared by LSH. Cross-language detection is unaffected. (rare as that may be in real-world situations)

## Semantic change to note

Wildcard (`"*"`) rules are now explicitly yielded before language-specific rules, with deduplication to handle the edge case of a rule listing both `"*"` and a specific language. No rules currently use `"*"`, but this establishes well-defined, safe semantics for when they are added.


🤖 Generated with [Claude Code](https://claude.ai/claude-code)