### PR TITLE
Skip apply_rules loop for nodes with no query matches

### DIFF
--- a/treepeat/pipeline/rules/engine.py
+++ b/treepeat/pipeline/rules/engine.py
@@ -24,6 +24,12 @@ class RuleEngine:
         self._action_handlers = self._build_action_handlers()
         self._compiled_queries: dict[tuple[str, str], Query] = {}
         self._query_matches_cache: dict[int, list[dict[str, Any]]] = {}
+        # Pre-partition rules by language for O(1) lookup during shingling.
+        # "*" entries are rules that match all languages.
+        self._rules_by_language: dict[str, list[Rule]] = {}
+        for rule in rules:
+            for lang in rule.languages:
+                self._rules_by_language.setdefault(lang, []).append(rule)
         self._source: bytes | None = None  # Store source for value extraction
 
     def _build_action_handlers(
@@ -221,8 +227,15 @@ class RuleEngine:
         return name, value
 
     def _iter_matching_rules(self, language: str) -> Iterable[Rule]:
-        for rule in self.rules:
-            if rule.matches_language(language):
+        # Yield wildcard rules first, then language-specific rules.
+        # Deduplication guard handles the (currently unused) case where a rule
+        # lists both "*" and a specific language in its languages field.
+        seen: set[int] = set()
+        for rule in self._rules_by_language.get("*", []):
+            seen.add(id(rule))
+            yield rule
+        for rule in self._rules_by_language.get(language, []):
+            if id(rule) not in seen:
                 yield rule
 
     def _apply_rule_state(
@@ -284,7 +297,7 @@ class RuleEngine:
 
         # Pre-execute all queries once and cache results indexed by node.id
         self._query_matches_cache = self._get_all_matches(
-            root_node, [r for r in self.rules if r.matches_language(language)], language
+            root_node, list(self._iter_matching_rules(language)), language
         )
 
     def get_region_extraction_rules(self, language: str) -> list[tuple[str, str]]:
@@ -293,8 +306,8 @@ class RuleEngine:
         Returns list of tuples: (query, region_type)
         """
         region_rules = []
-        for rule in self.rules:
-            if rule.action == RuleAction.EXTRACT_REGION and rule.matches_language(language):
+        for rule in self._iter_matching_rules(language):
+            if rule.action == RuleAction.EXTRACT_REGION:
                 region_type = rule.params.get("region_type")
                 if region_type:
                     region_rules.append((rule.query, region_type))

--- a/treepeat/pipeline/rules/engine.py
+++ b/treepeat/pipeline/rules/engine.py
@@ -264,6 +264,11 @@ class RuleEngine:
         root_node: Optional[Node] = None,
     ) -> tuple[Optional[str], Optional[str]]:
         """Apply all matching rules to a node."""
+        # Fast path: precompute_queries runs all queries upfront and indexes
+        # matched nodes by ID. A node absent from the cache had no rule matches.
+        if node.id not in self._query_matches_cache:
+            return None, None
+
         node_type = node_name or node.type
         name = None
         value = None


### PR DESCRIPTION
## Summary

- `apply_rules` is called once per AST node during shingling. Profiling django (25,347 regions, ~6.2M node traversals) after PRs #93 and #94 showed 56M calls to `_apply_rule_state` — roughly 9 rules × 6.2M nodes — even though most AST nodes have no rule matches at all. Only specific node types (identifiers, literals, comments) are targeted by rules.
- `precompute_queries` already indexes every matched node by ID. A single `node.id not in self._query_matches_cache` check at the top of `apply_rules` short-circuits the entire rule loop for unmatched nodes, eliminating per-rule overhead for the common case.

## Performance

Note: PRs #93 and #94 changes were applied as the before baseline.

| Repo | Before | After | Δ |
|---|---|---|---|
| requests | 2.8s | 2.3s | −18% |
| flask | 3.2s | 2.8s | −13% |
| redux-toolkit | 25.0s | 22.2s | −11% |
| nestjs | 16.4s | 16.3s | −1% (I/O-bound) |
| django | 114.8s | 99.6s | −13% |

## Correctness

- All 96 existing tests pass
- Clone counts on five real repos and twelve synthetic correctness suites are unchanged

## Note on cache invariant

`apply_rules` relies on `precompute_queries` having been called first to populate `_query_matches_cache`. All call sites in the pipeline (`shingle.py`, `treesitter.py`) already uphold this invariant — it is not a new requirement introduced by this change.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)