### PR TITLE
Speed up rule application for unmatched nodes

### DIFF
--- a/treepeat/pipeline/rules/engine.py
+++ b/treepeat/pipeline/rules/engine.py
@@ -274,6 +274,11 @@ class RuleEngine:
         value = None
         root_node = root_node or node
 
+        # Most AST nodes do not match any normalization rule. Avoid scanning the
+        # rule list when precomputed query matches show this node has no work.
+        if node.id not in self._query_matches_cache:
+            return None, None
+
         # Apply rules in the order they are defined.
         # Later matching rules for the same node component (name or value) will overwrite earlier ones.
         for rule in self._iter_matching_rules(language):
@@ -294,7 +299,8 @@ class RuleEngine:
     ) -> None:
         """Pre-execute all queries for a root node to populate the cache.
 
-        This executes all queries once and indexes matches by node ID for O(1) lookup.
+        This executes all queries once and indexes matches by node ID, which
+        makes non-matching nodes cheap to skip during rule application.
         Call this once per region after reset_identifiers().
         """
         # Store source for use in anonymization


### PR DESCRIPTION
## Summary

Speed up rule application during shingling by returning early when a node has no precomputed query matches.

`RuleEngine.precompute_queries()` already indexes normalization-rule matches by `node.id`. During AST traversal, most nodes do not match any normalization rule, but `apply_rules()` still scanned the full rule list for each unmatched node. This adds a fast path that skips that scan when the node is absent from the query-match cache. (a common case)

Also updates the `precompute_queries()` docstring to avoid overstating the cache as full O(1) rule application. The cache makes non-matching nodes cheap to skip; matched nodes still evaluate rule ordering semantics.

Performance harness, before vs after this change:

Real-world repos total elapsed:
before: 162.861s
after:  141.060s
delta:  -13.39%

Per-repo elapsed:

| Repo | Before | After | Delta | Clones |
|---|---:|---:|---:|---:|
| requests | 3.046s | 2.204s | -27.63% | 4 -> 4 |
| flask | 3.127s | 2.851s | -8.82% | 10 -> 10 | 
| redux-toolkit | 27.332s | 22.707s | -16.92% | 211 -> 211 |
| nestjs | 16.550s | 16.107s | -2.67% | 16 -> 16 |
| django | 112.806s | 97.191s | -13.84% | 100 -> 100 |

Full django scan now under 100s!

## Validation

Full test suite & additional local checks.