### PR TITLE
Fix JS-family identifier anonymization ruleset

### DIFF
--- a/tests/pipeline/languages/test_javascript_rules.py
+++ b/tests/pipeline/languages/test_javascript_rules.py
@@ -1,4 +1,83 @@
+from pathlib import Path
+
+import pytest
+
+from treepeat.models.similarity import Region
 from treepeat.pipeline.languages.javascript import JavaScriptConfig
+from treepeat.pipeline.languages.jsx import JsxConfig
+from treepeat.pipeline.languages.tsx import TsxConfig
+from treepeat.pipeline.languages.typescript import TypeScriptConfig
+from treepeat.pipeline.parse import parse_source_code
+from treepeat.pipeline.region_extraction import ExtractedRegion
+from treepeat.pipeline.rules.engine import RuleEngine
+from treepeat.pipeline.shingle import ASTShingler
+
+
+def _shingle_tokens(config, language: str, source: str, loose: bool) -> list[str]:
+    rules = config.get_loose_rules() if loose else config.get_default_rules()
+    engine = RuleEngine(rules)
+    source_bytes = source.encode("utf-8")
+    parsed = parse_source_code(source_bytes, language, Path("test_file"))
+    region = Region(
+        path=Path("test_file"),
+        language=language,
+        region_type="test",
+        region_name="test",
+        start_line=1,
+        end_line=source.count("\n") + 1,
+    )
+    extracted_region = ExtractedRegion(region=region, node=parsed.root_node)
+
+    engine.reset_identifiers()
+    engine.precompute_queries(extracted_region.node, language, source_bytes)
+    shingled = ASTShingler(rule_engine=engine, k=1).shingle_region(extracted_region, source_bytes)
+    return shingled.shingles.get_contents()
+
+
+@pytest.mark.parametrize(
+    ("config", "language"),
+    [
+        (JavaScriptConfig(), "javascript"),
+        (TypeScriptConfig(), "typescript"),
+        (JsxConfig(), "jsx"),
+        (TsxConfig(), "tsx"),
+    ],
+)
+def test_javascript_family_default_rules_preserve_identifiers(config, language):
+    tokens = _shingle_tokens(config, language, "const renamed = original;", loose=False)
+    token_str = " ".join(tokens)
+
+    assert "identifier(renamed)" in token_str
+    assert "identifier(original)" in token_str
+    assert "VAR_1" not in token_str
+
+
+@pytest.mark.parametrize(
+    ("config", "language"),
+    [
+        (JavaScriptConfig(), "javascript"),
+        (TypeScriptConfig(), "typescript"),
+        (JsxConfig(), "jsx"),
+        (TsxConfig(), "tsx"),
+    ],
+)
+def test_javascript_family_loose_rules_anonymize_identifiers(config, language):
+    tokens = _shingle_tokens(config, language, "const renamed = original;", loose=True)
+    token_str = " ".join(tokens)
+
+    assert any("identifier(VAR_" in t for t in tokens)
+    assert "renamed" not in token_str
+    assert "original" not in token_str
+
+
+def test_javascript_loose_rules_function_name_beats_anonymize():
+    # "Anonymize function names" (REPLACE_VALUE) runs after "Anonymize identifiers" (ANONYMIZE)
+    # and overwrites the value slot, so function names surface as FUNC not VAR_n.
+    tokens = _shingle_tokens(JavaScriptConfig(), "javascript", "function foo() {}", loose=True)
+    token_str = " ".join(tokens)
+
+    assert "identifier(FUNC)" in token_str
+    assert "foo" not in token_str
 
 
 def test_javascript_rules_detailed(rule_tester):

--- a/tests/test_rules_factory.py
+++ b/tests/test_rules_factory.py
@@ -1,5 +1,13 @@
 from treepeat.config import PipelineSettings
-from treepeat.pipeline.rules_factory import build_rule_engine
+from treepeat.pipeline.rules_factory import build_rule_engine, get_ruleset_with_descriptions
+
+
+def _javascript_rule_names(ruleset: str) -> list[str]:
+    return [
+        rule.name
+        for rule, _ in get_ruleset_with_descriptions(ruleset)
+        if rule.matches_language("javascript")
+    ]
 
 
 def test_additional_regions_extend_default_rules() -> None:
@@ -41,3 +49,11 @@ def test_excluded_regions_with_additional_regions() -> None:
     assert "function_definition" not in region_types
     assert "class_definition" in region_types
     assert "decorated_definition" in region_types
+
+
+def test_javascript_identifier_anonymization_is_only_in_loose_ruleset() -> None:
+    default_rule_names = _javascript_rule_names("default")
+    loose_rule_names = _javascript_rule_names("loose")
+
+    assert "Anonymize identifiers" not in default_rule_names
+    assert "Anonymize identifiers" in loose_rule_names

--- a/treepeat/pipeline/languages/javascript.py
+++ b/treepeat/pipeline/languages/javascript.py
@@ -21,14 +21,6 @@ class JavaScriptConfig(LanguageConfig):
                 action=RuleAction.REMOVE,
             ),
             Rule(
-                name="Anonymize identifiers",
-                languages=["javascript", "typescript", "tsx", "jsx"],
-                query="[(identifier) (property_identifier)] @id",
-                target="id",
-                action=RuleAction.ANONYMIZE,
-                params={"prefix": "VAR"},
-            ),
-            Rule(
                 name="Anonymize function names",
                 languages=["javascript", "typescript", "tsx", "jsx"],
                 query="[(function_declaration (identifier) @name) (method_definition (property_identifier) @name)]",
@@ -56,6 +48,14 @@ class JavaScriptConfig(LanguageConfig):
 
     def get_loose_rules(self) -> list[Rule]:
         return [
+            Rule(
+                name="Anonymize identifiers",
+                languages=["javascript", "typescript", "tsx", "jsx"],
+                query="[(identifier) (property_identifier)] @id",
+                target="id",
+                action=RuleAction.ANONYMIZE,
+                params={"prefix": "VAR"},
+            ),
             Rule(
                 name="Anonymize literal values",
                 languages=["javascript", "typescript", "tsx", "jsx"],


### PR DESCRIPTION
## Summary

Fixes #90 

Move generic JavaScript-family identifier anonymization out of the `default` ruleset and into `loose`. (same as other languages)

Before this change, JavaScript, TypeScript, JSX, and TSX default normalization anonymized all identifier and property_identifier nodes. Other languages reserve broad identifier anonymization for loose, while default generally normalizes higher-level names such as functions/classes and removes imports/comments. That made JS-family detect behavior looser than the rest of the language configs.

After this change:

- `default` still removes imports/comments and normalizes function/class names
- `default` preserves ordinary local identifiers and property identifiers
- `loose` still anonymizes generic identifiers, literals, collections, and expressions
- No noticeable change to performance. If anyone was relying on the previous incorrect behavior, they'll notice a difference in the results though.

## Testing

Added regression coverage at both the behavior and ruleset-definition levels. 100% pass.