### PR TITLE
Escape special characters in file paths for Rich markup

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,68 @@
+"""Tests for display functions with special characters in file paths."""
+
+import importlib
+import io
+from pathlib import Path
+
+from rich.console import Console
+
+from treepeat.models.similarity import Region, SimilarRegionGroup
+
+detect_module = importlib.import_module("treepeat.cli.commands.detect")
+
+
+def _make_region(path_str: str, start_line: int = 1, end_line: int = 10) -> Region:
+    return Region(
+        path=Path(path_str),
+        language="typescript",
+        region_type="function",
+        region_name="handler",
+        start_line=start_line,
+        end_line=end_line,
+    )
+
+
+def _capture_display_group(group: SimilarRegionGroup, monkeypatch) -> str:
+    buf = io.StringIO()
+    test_console = Console(file=buf, markup=True, highlight=False, width=200)
+    monkeypatch.setattr(detect_module, "console", test_console)
+    detect_module._display_group(group)
+    return buf.getvalue()
+
+
+class TestDisplayGroupSpecialCharPaths:
+    def test_bracket_path_id_segment_displayed_correctly(self, monkeypatch):
+        """Path with [id] segment must not be swallowed by Rich markup parsing."""
+        path = "packages/web/src/pages/api/collections/[id]/people/handler.ts"
+        region1 = _make_region(path)
+        region2 = _make_region("other/path/handler.ts")
+        group = SimilarRegionGroup(regions=[region1, region2], similarity=0.9)
+
+        output = _capture_display_group(group, monkeypatch)
+
+        assert "[id]" in output
+        assert "packages/web/src/pages/api/collections/[id]/people/handler.ts" in output
+
+    def test_bracket_path_multiple_segments_displayed_correctly(self, monkeypatch):
+        """Path with multiple bracket segments must render all of them."""
+        path = "src/pages/[locale]/blog/[slug]/index.ts"
+        region1 = _make_region(path)
+        region2 = _make_region("other/handler.ts")
+        group = SimilarRegionGroup(regions=[region1, region2], similarity=0.85)
+
+        output = _capture_display_group(group, monkeypatch)
+
+        assert "[locale]" in output
+        assert "[slug]" in output
+        assert "src/pages/[locale]/blog/[slug]/index.ts" in output
+
+    def test_plain_path_still_displayed(self, monkeypatch):
+        """Paths without special characters continue to display correctly."""
+        path = "packages/web/src/handlers/api.ts"
+        region1 = _make_region(path)
+        region2 = _make_region("other/handler.ts")
+        group = SimilarRegionGroup(regions=[region1, region2], similarity=0.9)
+
+        output = _capture_display_group(group, monkeypatch)
+
+        assert path in output

--- a/treepeat/cli/commands/detect.py
+++ b/treepeat/cli/commands/detect.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import click
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from treepeat.config import (
@@ -203,7 +204,7 @@ def _display_group(group: SimilarRegionGroup, show_diff: bool = False) -> None:
         prefix = "  - " if i == 0 else "    "
         region_display = _format_region_name(region)
         console.print(
-            f"{prefix}{region.path} [{region.start_line}:{region.end_line}] "
+            f"{prefix}{escape(str(region.path))} [{region.start_line}:{region.end_line}] "
             f"({lines} lines) {region_display}"
         )
 

--- a/treepeat/diff.py
+++ b/treepeat/diff.py
@@ -2,6 +2,7 @@ import difflib
 from collections.abc import Sequence
 
 from rich.console import Console
+from rich.markup import escape
 
 from treepeat.models.similarity import Region
 from treepeat.terminal_detect import get_diff_colors
@@ -164,8 +165,8 @@ def _print_inserted_lines(lines2: list[str], j1: int, j2: int, col_width: int) -
 def _print_diff_header(region1: Region, region2: Region, col_width: int) -> None:
     """Print diff header with file information."""
     console.print("[bold]Diff:[/bold]")
-    header1 = f"{region1.path}:{region1.start_line}-{region1.end_line}"
-    header2 = f"{region2.path}:{region2.start_line}-{region2.end_line}"
+    header1 = f"{escape(str(region1.path))}:{region1.start_line}-{region1.end_line}"
+    header2 = f"{escape(str(region2.path))}:{region2.start_line}-{region2.end_line}"
     console.print(f"[dim]{header1:<{col_width}}[/dim]│[dim]{header2:<{col_width}}[/dim]")
     console.print(f"{'-' * col_width}│{'-' * col_width}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1009,7 +1009,7 @@ wheels = [
 
 [[package]]
 name = "treepeat"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Fix display of file paths containing square brackets (e.g., `[id]`, `[slug]`) by escaping them before passing to Rich's console output. Square brackets are Rich markup syntax and were being interpreted as formatting directives rather than literal path characters.

## Changes
- **treepeat/cli/commands/detect.py**: Escape file paths in `_display_group()` using `rich.markup.escape()` before console output
- **treepeat/diff.py**: Escape file paths in `_print_diff_header()` using `rich.markup.escape()` before console output
- **tests/test_display.py**: Add comprehensive test suite covering:
  - Paths with single bracket segments (e.g., `[id]`)
  - Paths with multiple bracket segments (e.g., `[locale]`, `[slug]`)
  - Plain paths without special characters (regression test)

## Implementation Details
The fix uses Rich's built-in `escape()` function from `rich.markup` to safely escape special characters in file paths before they're passed to console output. This ensures that bracket characters in dynamic route segments (common in Next.js and similar frameworks) are displayed literally rather than being interpreted as Rich markup.

https://claude.ai/code/session_015tnf9mDoRnsgZ55WnJto4n