### PR TITLE
Remove wildcard rule language grouping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ lint:
 	uv run ruff check .
 
 vulture:
-  # vulture erroneously flags pydantic model_config settings as unused.
-	uv run vulture --min-confidence 55 --ignore-names 'model_config' treepeat
+	# vulture cannot detect pydantic validator methods referenced via decorators.
+	uv run vulture --min-confidence 55 --ignore-names 'model_config,_reject_wildcard_languages' treepeat
 
 fix:
 	uv run ruff check . --fix

--- a/tests/pipeline/rules/test_models.py
+++ b/tests/pipeline/rules/test_models.py
@@ -1,0 +1,8 @@
+import pytest
+
+from treepeat.pipeline.rules.models import Rule
+
+
+def test_rule_rejects_wildcard_language() -> None:
+    with pytest.raises(ValueError, match="Wildcard rule languages"):
+        Rule(name="wildcard", languages=["*", "python"], query="(identifier) @id")

--- a/tests/pipeline/rules/test_parser.py
+++ b/tests/pipeline/rules/test_parser.py
@@ -1,0 +1,16 @@
+import pytest
+
+from treepeat.pipeline.rules.parser import RuleParseError, _parse_yaml_rule
+
+
+def test_parse_yaml_rule_rejects_wildcard_language() -> None:
+    with pytest.raises(RuleParseError, match="Wildcard rule languages"):
+        _parse_yaml_rule(
+            {
+                "name": "wildcard",
+                "languages": ["*", "python"],
+                "query": "(identifier) @id",
+                "action": "remove",
+            },
+            "test",
+        )

--- a/tests/test_rules_factory.py
+++ b/tests/test_rules_factory.py
@@ -1,3 +1,6 @@
+import pytest
+from pydantic import ValidationError
+
 from treepeat.config import PipelineSettings
 from treepeat.pipeline.rules_factory import build_rule_engine, get_ruleset_with_descriptions
 
@@ -57,3 +60,27 @@ def test_javascript_identifier_anonymization_is_only_in_loose_ruleset() -> None:
 
     assert "Anonymize identifiers" not in default_rule_names
     assert "Anonymize identifiers" in loose_rule_names
+
+
+def test_settings_reject_wildcard_region_filter_language() -> None:
+    with pytest.raises(ValidationError, match="Wildcard language '\\*' is not supported"):
+        PipelineSettings(
+            rules={"region_filters": {"*": {"function_definition"}, "python": {"class_definition"}}}
+        )
+
+
+def test_settings_reject_wildcard_additional_region_language() -> None:
+    with pytest.raises(ValidationError, match="Wildcard language '\\*' is not supported"):
+        PipelineSettings(rules={"additional_regions": {"*": {"function_definition"}}})
+
+
+def test_settings_reject_wildcard_language_on_assignment() -> None:
+    settings = PipelineSettings()
+
+    with pytest.raises(ValidationError, match="Wildcard language '\\*' is not supported"):
+        settings.rules.additional_regions = {"*": {"function_definition"}}
+
+
+def test_settings_reject_wildcard_excluded_region_language() -> None:
+    with pytest.raises(ValidationError, match="Wildcard language '\\*' is not supported"):
+        PipelineSettings(rules={"excluded_regions": {"*": {"function_definition"}}})

--- a/treepeat/config.py
+++ b/treepeat/config.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -7,6 +7,7 @@ class RulesSettings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_prefix="RULES_",
+        validate_assignment=True,
     )
 
     ruleset: str = Field(
@@ -35,6 +36,20 @@ class RulesSettings(BaseSettings):
             "(e.g., {'python': {'function_definition', 'class_definition'}})"
         ),
     )
+
+    @field_validator("region_filters", "additional_regions", "excluded_regions")
+    @classmethod
+    def _reject_wildcard_languages(
+        cls, value: dict[str, set[str]]
+    ) -> dict[str, set[str]]:
+        # Keep runtime-mutated settings aligned with Rule's language invariant.
+        # CLI configuration builds a settings object first, then assigns these
+        # mappings from parsed options.
+        if "*" in value:
+            raise ValueError(
+                "Wildcard language '*' is not supported; specify explicit languages"
+            )
+        return value
 
 
 class ShingleSettings(BaseSettings):

--- a/treepeat/pipeline/rules/engine.py
+++ b/treepeat/pipeline/rules/engine.py
@@ -25,7 +25,6 @@ class RuleEngine:
         self._compiled_queries: dict[tuple[str, str], Query] = {}
         self._query_matches_cache: dict[int, list[dict[str, Any]]] = {}
         # Pre-partition rules by language for O(1) lookup during shingling.
-        # "*" entries are rules that match all languages.
         self._rules_by_language: dict[str, list[Rule]] = {}
         for rule in rules:
             for lang in set(rule.languages):
@@ -228,20 +227,7 @@ class RuleEngine:
         return name, value
 
     def _iter_matching_rules(self, language: str) -> Iterable[Rule]:
-        # Yield wildcard rules first, then language-specific rules.
-        # Deduplication guard handles the (currently unused) case where a rule
-        # lists both "*" and a specific language in its languages field.
-        wildcard_rules = self._rules_by_language.get("*", [])
-        if not wildcard_rules:
-            yield from self._rules_by_language.get(language, [])
-            return
-        seen: set[int] = set()
-        for rule in wildcard_rules:
-            seen.add(id(rule))
-            yield rule
-        for rule in self._rules_by_language.get(language, []):
-            if id(rule) not in seen:
-                yield rule
+        yield from self._rules_by_language.get(language, [])
 
     def _apply_rule_state(
         self,

--- a/treepeat/pipeline/rules/models.py
+++ b/treepeat/pipeline/rules/models.py
@@ -37,9 +37,15 @@ class Rule:
     # full matched-node bytes are used.
     injection_content_query: str | None = None
 
+    def __post_init__(self) -> None:
+        if "*" in self.languages:
+            raise ValueError(
+                "Wildcard rule languages ('*') are not supported; specify explicit languages"
+            )
+
     def matches_language(self, language: str) -> bool:
         """Check if this rule applies to the given language."""
-        return "*" in self.languages or language in self.languages
+        return language in self.languages
 
     def resolve_injection_language(self, node: Node, source: bytes) -> str | None:
         """Return the target language for injection, or None if not applicable."""

--- a/treepeat/pipeline/rules/parser.py
+++ b/treepeat/pipeline/rules/parser.py
@@ -38,6 +38,12 @@ def _parse_yaml_rule(rule_dict: dict[str, Any], ruleset_name: str) -> Rule:
     if isinstance(languages, str):
         languages = [languages]
 
+    if "*" in languages:
+        raise RuleParseError(
+            f"Rule '{name}' in ruleset '{ruleset_name}' is invalid: "
+            "Wildcard rule languages ('*') are not supported; specify explicit languages"
+        )
+
     return Rule(
         name=name,
         languages=languages,


### PR DESCRIPTION
## Summary

Closes #98.

This removes wildcard ("*") rule-language handling from the rules engine. Tree-sitter rules are language-specific in practice, and there are no current wildcard rules, so the engine can now assume every rule is indexed and matched by explicit language.

The implementation is a little defensive, intentionally:
1. it makes the new invariant self-documenting in code, and
2. it ensures the simplified assumptions continue to hold, so the rest of the code can stay simple.

## Changes

- Remove wildcard grouping/matching from RuleEngine._iter_matching_rules.
- Update Rule.matches_language() to check only explicit language membership.
- Reject Rule(languages=[...]) values containing "*".
- Reject wildcard languages in YAML rule parsing with a contextual RuleParseError.
- Reject wildcard language keys in rule-related settings, including assignment-time validation, because CLI configuration mutates those mappings after constructing settings.
- Add tests for direct rule construction, parser behavior, and settings validation.

## Notes

- docs/adr/0003-use-rules.md still mentions wildcard DSL syntax. I left it unchanged because it is historical ADR text, not current user-facing behavior.
- The Makefile vulture ignore now includes the Pydantic validator method. Vulture does not see decorator-referenced Pydantic validators as used, so this keeps make ci green without changing runtime code.

## Verification

All checks passed.
