### PR TITLE
Add YAML language support and ```yaml markdown code block injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Pull requests welcome: This is very much an proof of concept - I'm happy with it, but I haven't supported very many languages at present. PRs welcome!
 
-Languages supported: astro, bash, css, go, html, javascript, markdown, python, sql, typescript, java, kotlin, rust
+Languages supported: astro, bash, css, go, html, javascript, markdown, python, sql, typescript, java, kotlin, rust, yaml
 
 ## Usage
 

--- a/tests/fixtures/markdown/guide.md
+++ b/tests/fixtures/markdown/guide.md
@@ -44,6 +44,24 @@ function check_requirements() {
 }
 ```
 
+## YAML Example
+
+Describe a deployable service:
+
+```yaml
+service:
+  name: treepeat
+  port: 8080
+  replicas: 3
+  env:
+    - LOG_LEVEL=info
+    - CACHE=redis
+  healthcheck:
+    path: /healthz
+    interval: 30
+    timeout: 5
+```
+
 ## Plain Text Example
 
 This block has no language tag and should not trigger injection:

--- a/tests/fixtures/yaml/config.yaml
+++ b/tests/fixtures/yaml/config.yaml
@@ -1,0 +1,11 @@
+service:
+  name: treepeat
+  port: 8080
+  replicas: 3
+  env:
+    - LOG_LEVEL=info
+    - CACHE=redis
+  healthcheck:
+    path: /healthz
+    interval: 30
+    timeout: 5

--- a/tests/pipeline/languages/test_yaml.py
+++ b/tests/pipeline/languages/test_yaml.py
@@ -1,0 +1,150 @@
+"""Tests for YAML language configuration and Markdown ```yaml code block injection."""
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import parse_fixture
+from treepeat.pipeline.languages import LANGUAGE_CONFIGS
+from treepeat.pipeline.languages.markdown import _resolve_code_block_language
+from treepeat.pipeline.languages.yaml import YAMLConfig
+from treepeat.pipeline.parse import detect_language, parse_file
+from treepeat.pipeline.region_extraction import extract_all_regions
+from treepeat.pipeline.rules.engine import RuleEngine, build_default_rules, build_loose_rules
+from treepeat.pipeline.shingle import ASTShingler
+
+FIXTURE_DIR = Path(__file__).parent.parent.parent / "fixtures"
+fixture_config = FIXTURE_DIR / "yaml" / "config.yaml"
+fixture_guide = FIXTURE_DIR / "markdown" / "guide.md"
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_registered_in_configs():
+    assert "yaml" in LANGUAGE_CONFIGS
+    assert isinstance(LANGUAGE_CONFIGS["yaml"], YAMLConfig)
+
+
+@pytest.mark.parametrize("ext", [".yaml", ".yml"])
+def test_yaml_extensions_detected(ext):
+    assert detect_language(Path(f"foo{ext}")) == "yaml"
+
+
+def test_yaml_region_extraction_rules_exist():
+    labels = [r.label for r in YAMLConfig().get_region_extraction_rules()]
+    assert "block_mapping_pair" in labels
+
+
+# ---------------------------------------------------------------------------
+# Standalone YAML parsing / extraction
+# ---------------------------------------------------------------------------
+
+
+def test_parse_yaml_no_errors():
+    parsed = parse_file(fixture_config)
+    assert parsed.language == "yaml"
+    assert not parsed.root_node.has_error
+
+
+@pytest.mark.parametrize("rules", [
+    [rule for rule, _ in build_default_rules()],
+    [rule for rule, _ in build_loose_rules()],
+])
+def test_yaml_regions_extracted(rules):
+    parsed = parse_fixture(fixture_config, "yaml")
+    engine = RuleEngine(rules)
+    regions = extract_all_regions([parsed], engine)
+    assert regions, "Expected at least one extracted region from the YAML fixture"
+
+
+# ---------------------------------------------------------------------------
+# Markdown ```yaml injection
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_yaml_block_injected():
+    parsed = parse_file(fixture_guide)
+    engine = RuleEngine([r for r, _ in build_default_rules()])
+    regions = extract_all_regions([parsed], engine)
+
+    injected = [r for r in regions if r.injected_language == "yaml"]
+    assert injected, "Expected the ```yaml block in guide.md to be injected as yaml"
+    region = injected[0]
+    assert region.injected_tree is not None
+    assert region.injected_source is not None
+    # Region metadata preserves the file language, not the injection language.
+    assert region.region.language == "markdown"
+
+
+def test_yml_alias_resolves_to_yaml():
+    """A ```yml fence resolves to the yaml language via the info-string alias."""
+    from tree_sitter_language_pack import get_parser
+
+    source = b"```yml\nname: test\n```\n"
+    tree = get_parser("markdown").parse(source)
+
+    fenced_node = None
+    for child in [tree.root_node, *tree.root_node.children]:
+        fenced_node = next(
+            (n for n in child.children if n.type == "fenced_code_block"), None
+        )
+        if fenced_node is not None:
+            break
+
+    assert fenced_node is not None, "Could not find fenced_code_block node"
+    assert _resolve_code_block_language(fenced_node, source) == "yaml"
+
+
+# ---------------------------------------------------------------------------
+# Cross-file shingle similarity: embedded YAML mirrors a standalone YAML file
+# ---------------------------------------------------------------------------
+
+
+def _shingle_injected_region(region, engine, shingler):
+    engine.reset_identifiers()
+    engine.precompute_queries(
+        region.injected_tree.root_node,
+        region.injected_language,
+        region.injected_source,
+    )
+    shingled = shingler.shingle_region(region, region.injected_source)
+    return {s.content for s in shingled.shingles.shingles}
+
+
+def _shingle_standalone_file(path, language, rules):
+    parsed = parse_fixture(path, language)
+    engine = RuleEngine(rules)
+    shingler = ASTShingler(rule_engine=engine, k=3)
+    regions = extract_all_regions([parsed], engine)
+
+    all_shingles: set[str] = set()
+    for region in regions:
+        engine.reset_identifiers()
+        engine.precompute_queries(region.node, language, parsed.source)
+        shingled = shingler.shingle_region(region, parsed.source)
+        all_shingles.update(s.content for s in shingled.shingles.shingles)
+    return all_shingles
+
+
+def test_embedded_yaml_shingles_overlap_with_standalone():
+    """A YAML block embedded in markdown shares shingles with the same
+    content in a standalone .yaml file, so similarity detection links them."""
+    rules = [r for r, _ in build_loose_rules()]
+
+    md_engine = RuleEngine(rules)
+    md_shingler = ASTShingler(rule_engine=md_engine, k=3)
+    md_parsed = parse_file(fixture_guide)
+    md_regions = extract_all_regions([md_parsed], md_engine)
+    embedded = next(r for r in md_regions if r.injected_language == "yaml")
+    md_shingles = _shingle_injected_region(embedded, md_engine, md_shingler)
+
+    standalone_shingles = _shingle_standalone_file(fixture_config, "yaml", rules)
+
+    assert md_shingles, "No shingles produced from markdown yaml block"
+    assert standalone_shingles, "No shingles produced from standalone yaml file"
+    assert md_shingles & standalone_shingles, (
+        "Markdown yaml block and standalone yaml file share no shingles"
+    )

--- a/treepeat/pipeline/languages/__init__.py
+++ b/treepeat/pipeline/languages/__init__.py
@@ -14,6 +14,7 @@ from .rust import RustConfig
 from .sql import SQLConfig
 from .tsx import TsxConfig
 from .typescript import TypeScriptConfig
+from .yaml import YAMLConfig
 
 # Registry mapping language names to their configurations
 LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
@@ -32,6 +33,7 @@ LANGUAGE_CONFIGS: dict[str, LanguageConfig] = {
     "sql": SQLConfig(),
     "tsx": TsxConfig(),
     "typescript": TypeScriptConfig(),
+    "yaml": YAMLConfig(),
 }
 
 LANGUAGE_EXTENSIONS: dict[str, list[str]] = {
@@ -50,6 +52,7 @@ LANGUAGE_EXTENSIONS: dict[str, list[str]] = {
     "sql": [".sql"],
     "tsx": [".tsx"],
     "typescript": [".ts"],
+    "yaml": [".yaml", ".yml"],
 }
 
 # Languages that share a tree-sitter grammar with another language.
@@ -85,4 +88,5 @@ __all__ = [
     "GoConfig",
     "MarkdownConfig",
     "AstroConfig",
+    "YAMLConfig",
 ]

--- a/treepeat/pipeline/languages/markdown.py
+++ b/treepeat/pipeline/languages/markdown.py
@@ -8,6 +8,11 @@ from .base import LanguageConfig, RegionExtractionRule
 
 logger = logging.getLogger(__name__)
 
+# Common info-string spellings that map onto a supported language name.
+_INFO_STRING_ALIASES = {
+    "yml": "yaml",
+}
+
 
 def _resolve_code_block_language(node: Node, source: bytes) -> str:
     """Return the language declared in a fenced_code_block's info_string.
@@ -29,6 +34,7 @@ def _resolve_code_block_language(node: Node, source: bytes) -> str:
                 return ""
             # Language identifiers may have extra text (e.g. "python title='foo'")
             lang = lang_text.split()[0].lower()
+            lang = _INFO_STRING_ALIASES.get(lang, lang)
             from treepeat.pipeline.languages import LANGUAGE_CONFIGS  # lazy import avoids circular import
             if lang not in LANGUAGE_CONFIGS:
                 logger.warning(

--- a/treepeat/pipeline/languages/yaml.py
+++ b/treepeat/pipeline/languages/yaml.py
@@ -1,0 +1,51 @@
+from treepeat.pipeline.rules.models import Rule, RuleAction
+
+from .base import LanguageConfig, RegionExtractionRule
+
+
+class YAMLConfig(LanguageConfig):
+    """Configuration for YAML language.
+
+    Supports both standalone ``.yaml``/``.yml`` files and ` ```yaml ` fenced
+    code blocks embedded in Markdown (via language injection).
+    """
+
+    def get_default_rules(self) -> list[Rule]:
+        return [
+            Rule(
+                name="Ignore comments",
+                languages=["yaml"],
+                query="(comment) @comment",
+                action=RuleAction.REMOVE,
+            ),
+        ]
+
+    def get_loose_rules(self) -> list[Rule]:
+        return [
+            *self.get_default_rules(),
+            Rule(
+                name="Anonymize scalar values",
+                languages=["yaml"],
+                query=(
+                    "["
+                    "(integer_scalar) (float_scalar) (boolean_scalar)"
+                    " (double_quote_scalar) (single_quote_scalar) (block_scalar)"
+                    "] @lit"
+                ),
+                action=RuleAction.REPLACE_VALUE,
+                params={"value": "<LIT>"},
+            ),
+            Rule(
+                name="Anonymize anchor and alias names",
+                languages=["yaml"],
+                query="[(anchor_name) (alias_name)] @ref",
+                action=RuleAction.REPLACE_VALUE,
+                params={"value": "<REF>"},
+            ),
+        ]
+
+    def get_region_extraction_rules(self) -> list[RegionExtractionRule]:
+        return [
+            RegionExtractionRule.from_node_type("block_mapping_pair"),
+            RegionExtractionRule.from_node_type("block_sequence"),
+        ]


### PR DESCRIPTION
## Overview

Adds YAML as a supported language. This means:

- Standalone `.yaml` / `.yml` files are now scanned for similar/duplicate blocks.
- ` ```yaml ` (and ` ```yml `) fenced code blocks inside Markdown are injected and shingled with YAML-specific normalization, so documentation config examples are matched against real YAML files — the same mechanism already used for `python`/`javascript`/`bash` blocks.

## Changes

- **`treepeat/pipeline/languages/yaml.py`** — new `YAMLConfig`:
  - default ruleset removes comments,
  - loose ruleset additionally anonymizes scalar values (numbers, booleans, quoted strings, block scalars) and anchor/alias names,
  - regions extracted from `block_mapping_pair` and `block_sequence` nodes.
- **`treepeat/pipeline/languages/__init__.py`** — register `yaml` in `LANGUAGE_CONFIGS`, map `.yaml`/`.yml` in `LANGUAGE_EXTENSIONS`, export `YAMLConfig`.
- **`treepeat/pipeline/languages/markdown.py`** — map the `yml` info-string spelling to `yaml` so both fence tags inject.
- **`README.md`** — add `yaml` to the supported-languages list.

## Tests

- `tests/fixtures/yaml/config.yaml` — standalone fixture.
- A ` ```yaml ` block added to `tests/fixtures/markdown/guide.md` mirroring that fixture.
- `tests/pipeline/languages/test_yaml.py` — covers registration/extension detection, standalone parsing + region extraction, markdown injection, the `yml` alias, and the cross-file shingle-overlap invariant (embedded YAML shares shingles with the standalone file).

Full suite passes (158 tests) and `ruff` is clean. Verified end-to-end via `treepeat detect`: an embedded ` ```yaml ` block is grouped with matching standalone `.yaml`/`.yml` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B32BThc1Hshxn7HHJoWR9U)_